### PR TITLE
Add Menu Selection Memory Feature and Improve Navigation in Carch

### DIFF
--- a/cxfs.sh
+++ b/cxfs.sh
@@ -5,19 +5,22 @@ GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
+last_main_menu_index=0  
+last_submenu_index=0    
+
 display_main_menu() {
     while true; do
         choice=$(whiptail --title "Linux System Arch Setup" \
                           --menu "Choose an option" 15 60 4 \
+                          --default-item "$((last_main_menu_index + 1))" \
                           "1" "Arch Setup" \
                           "2" "Help & Info" \
                           "3" "Exit" 3>&1 1>&2 2>&3)
 
         case $choice in
-            1) display_submenu ;;
-            2) display_help ;;
-            3) clear  
-               exit 0 ;;  
+            1) last_main_menu_index=0; display_submenu ;;
+            2) last_main_menu_index=1; display_help ;;
+            3) last_main_menu_index=2; clear; exit 0 ;;
         esac
     done
 }
@@ -46,8 +49,9 @@ display_submenu() {
 
         ((menu_height > 20)) && menu_height=20
 
-        CHOICE=$(dialog --title "Arch Setup Options" --menu "Select a script to run" \
-                "$menu_height" 60 ${#script_list[@]} "${script_list[@]}" 3>&1 1>&2 2>&3)
+        CHOICE=$(dialog --default-item "$((last_submenu_index + 1))" \
+                        --title "Arch Setup Options" --menu "Select a script to run" \
+                        "$menu_height" 60 ${#script_list[@]} "${script_list[@]}" 3>&1 1>&2 2>&3)
 
         EXIT_STATUS=$?
 
@@ -58,6 +62,7 @@ display_submenu() {
         selected=$((CHOICE - 1))
 
         if [[ $selected -lt ${#scripts[@]} ]]; then
+            last_submenu_index=$selected  
             run_script "${scripts[selected]}"
         else
             break


### PR DESCRIPTION
### Description

- [x] Added functionality to remember the last selected menu items for both the main menu and submenu.
- [ ] Fixed issue #11 
- [x] Improved/optimized existing functionality to enhance user experience.
- [ ] Bugs Fixes.
- [x] Feature Added: Added memory functionality for menu selections.
- [x] Menu Improvement: The main menu and submenu now retain the last selected choice when revisited.

### Context

This change enhances the user experience by allowing the main menu and submenu to remember the last selected option. It helps users quickly return to their previous choices, saving time and effort when navigating the menu. This update adds a new feature that improves the flow of the script, especially for repeated tasks or iterative setups.

### How Has This Been Tested?

- [x] Tested on Arch Linux with the `whiptail` and `dialog` dependencies.
- Verified that the last selected menu item is highlighted when returning to both the main menu and submenu.
- Tested different scenarios, including exiting scripts and navigating back, to ensure the functionality works as expected.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

### Screenshots (if applicable)

N/A

### Related Issues

Fix #11 Issue

### Additional Notes

- This change may impact future updates to the menu system; thorough testing is recommended after any modifications.
- Further enhancements could include adding configuration options for resetting the remembered selections.
