### PR TITLE
Remove Echo On Running Script

### DIFF
--- a/cxfs.sh
+++ b/cxfs.sh
@@ -48,13 +48,7 @@ display_scripts_menu() {
 
 run_script() {
     local script_name="$1"
-    echo "Running ${script_name}..."
-    if bash "./scripts/${script_name}.sh"; then
-        echo "${script_name} completed successfully. Press Enter to return to the menu."
-    else
-        echo "${script_name} failed to complete. Press Enter to return to the menu."
-    fi
-    read -r
+    ./scripts/${script_name}.sh
     display_scripts_menu
 }
 


### PR DESCRIPTION
### Description

When exiting from any script it tells you to press enter to go back to the menu. It becomes more unreasonable to put it on script. So I have removed it to make it more clean and easy to understand.

- [x] Added/updated scripts or configurations.
- [x] Remove Bad Script/Code.
- [ ] Fixed issue #[issue number].
- [x] Improved/optimized existing functionality.
- [ ] Bugs Fixes.
- [ ] Feature Added.
- [x] UI Enhancement.

### Context

This is a bit necessary to make the script cleaner and make user to run script more easily . Now it will not be difficult to understand the code.

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on [Arch Linux].

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.



