### PR TITLE
feat: Add New Commands

### DIFF
--- a/src/scripts/carch
+++ b/src/scripts/carch
@@ -12,9 +12,23 @@ NC='\033[0m'
 
 SCRIPT_DIR="./modules"
 LOG_FILE="$HOME/.config/carch/carch.log"
+LOG_MODE="false"
 
 CONFIG_DIR="$HOME/.config/carch"
 CONFIG_FILE="$CONFIG_DIR/carch.conf"
+
+if [[ -d "/dev/shm" ]]; then
+    TMP_DIR="/dev/shm/carch_tmp"
+else
+    TMP_DIR="/tmp/carch_tmp"
+fi
+mkdir -p "$TMP_DIR"
+
+cleanup_temp() {
+    rm -rf "$TMP_DIR" 2>/dev/null
+}
+
+trap cleanup_temp EXIT
 
 setup_logging() {
     mkdir -p "$(dirname "$LOG_FILE")"
@@ -27,7 +41,48 @@ setup_logging() {
 log_message() {
     local log_type="$1"
     local message="$2"
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [$log_type] $message" >>"$LOG_FILE"
+    
+    if [[ -n "$CARCH_DEBUG" ]] || [[ "$LOG_MODE" == "true" ]] || is_logging_enabled; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [$log_type] $message" >>"$LOG_FILE"
+    fi
+}
+
+is_logging_enabled() {
+    if [[ -f "$CONFIG_FILE" ]]; then
+        if grep -q "^LOGGING_ENABLED=true" "$CONFIG_FILE" 2>/dev/null; then
+            return 0
+        fi
+    fi
+    
+    return 1
+}
+
+enable_logging() {
+    mkdir -p "$CONFIG_DIR"
+    
+    if [[ -f "$CONFIG_FILE" ]]; then
+        if grep -q "^LOGGING_ENABLED=true" "$CONFIG_FILE"; then
+            echo -e "${YELLOW}Logging is already enabled in $CONFIG_FILE${RESET}"
+            echo -e "${CYAN}To disable logging, edit $CONFIG_FILE and change LOGGING_ENABLED=true to LOGGING_ENABLED=false${RESET}"
+            return 0
+        fi
+        
+        if grep -q "^LOGGING_ENABLED=false" "$CONFIG_FILE"; then
+            sed -i 's/^LOGGING_ENABLED=false/LOGGING_ENABLED=true/' "$CONFIG_FILE"
+            echo -e "${GREEN}Logging has been enabled in $CONFIG_FILE${RESET}"
+            echo -e "${CYAN}To disable logging, edit $CONFIG_FILE and change LOGGING_ENABLED=true to LOGGING_ENABLED=false${RESET}"
+            return 0
+        fi
+        
+        echo -e "\n# Logging settings\nLOGGING_ENABLED=true" >> "$CONFIG_FILE"
+        echo -e "${GREEN}Logging has been enabled in $CONFIG_FILE${RESET}"
+        echo -e "${CYAN}To disable logging, edit $CONFIG_FILE and change LOGGING_ENABLED=true to LOGGING_ENABLED=false${RESET}"
+    else
+        generate_config
+        sed -i 's/^LOGGING_ENABLED=false/LOGGING_ENABLED=true/' "$CONFIG_FILE"
+        echo -e "${GREEN}Logging has been enabled in newly created $CONFIG_FILE${RESET}"
+        echo -e "${CYAN}To disable logging, edit $CONFIG_FILE and change LOGGING_ENABLED=true to LOGGING_ENABLED=false${RESET}"
+    fi
 }
 
 detect_distro() {
@@ -42,8 +97,6 @@ detect_distro() {
         echo -e "${RED}Unknown${RESET}"
     fi
 }
-
-ARCH=$(uname -m)
 
 uninstall_carch() {
     detect_distro
@@ -115,7 +168,13 @@ terminal/Alacritty
 terminal/Kitty  
 system/Packages  
 
-# End of file
+# Display settings
+# Set DISABLE_PREVIEW=true to disable script previews in menus
+DISABLE_PREVIEW=false
+
+# Logging settings
+# Set LOGGING_ENABLED=true to enable permanent logging
+LOGGING_ENABLED=false
 EOL
         echo -e "${GREEN}Default configuration file created at $CONFIG_FILE.${RESET}"
         log_message "INFO" "Generated default configuration file."
@@ -123,6 +182,48 @@ EOL
         echo -e "${YELLOW}Configuration file already exists at $CONFIG_FILE.${RESET}"
         log_message "INFO" "Configuration file already exists."
     fi
+}
+
+disable_preview() {
+    mkdir -p "$CONFIG_DIR"
+    
+    if [[ -f "$CONFIG_FILE" ]]; then
+        if grep -q "^DISABLE_PREVIEW=true" "$CONFIG_FILE"; then
+            echo -e "${YELLOW}Preview is already disabled in $CONFIG_FILE${RESET}"
+            echo -e "${CYAN}To re-enable previews, edit $CONFIG_FILE and change DISABLE_PREVIEW=true to DISABLE_PREVIEW=false${RESET}"
+            return 0
+        fi
+        
+        if grep -q "^DISABLE_PREVIEW=false" "$CONFIG_FILE"; then
+            sed -i 's/^DISABLE_PREVIEW=false/DISABLE_PREVIEW=true/' "$CONFIG_FILE"
+            echo -e "${GREEN}Preview has been disabled in $CONFIG_FILE${RESET}"
+            echo -e "${CYAN}To re-enable previews, edit $CONFIG_FILE and change DISABLE_PREVIEW=true to DISABLE_PREVIEW=false${RESET}"
+            return 0
+        fi
+        
+        echo -e "\n# Display settings\nDISABLE_PREVIEW=true" >> "$CONFIG_FILE"
+        echo -e "${GREEN}Preview has been disabled in $CONFIG_FILE${RESET}"
+        echo -e "${CYAN}To re-enable previews, edit $CONFIG_FILE and change DISABLE_PREVIEW=true to DISABLE_PREVIEW=false${RESET}"
+    else
+        generate_config
+        sed -i 's/^DISABLE_PREVIEW=false/DISABLE_PREVIEW=true/' "$CONFIG_FILE"
+        echo -e "${GREEN}Preview has been disabled in newly created $CONFIG_FILE${RESET}"
+        echo -e "${CYAN}To re-enable previews, edit $CONFIG_FILE and change DISABLE_PREVIEW=true to DISABLE_PREVIEW=false${RESET}"
+    fi
+}
+
+is_preview_enabled() {
+    if [[ "$NO_PREVIEW" == "true" ]]; then
+        return 1
+    fi
+    
+    if [[ -f "$CONFIG_FILE" ]]; then
+        if grep -q "^DISABLE_PREVIEW=true" "$CONFIG_FILE" 2>/dev/null; then
+            return 1
+        fi
+    fi
+    
+    return 0
 }
 
 get_installed_version() {
@@ -163,13 +264,27 @@ load_selected_scripts() {
     scripts+=("Cancel")
 }
 
+cache_scripts() {
+    SCRIPTS_CACHE_FILE="$CONFIG_DIR/scripts_cache.txt"
+    
+    if [[ ! -f "$SCRIPTS_CACHE_FILE" ]] || [[ $(find "$SCRIPT_DIR" -newer "$SCRIPTS_CACHE_FILE" | wc -l) -gt 0 ]]; then
+        mkdir -p "$CONFIG_DIR"
+        find "$SCRIPT_DIR" -type f -name "*.sh" -print > "$SCRIPTS_CACHE_FILE"
+    fi
+    
+    return 0
+}
+
 load_all_scripts() {
     scripts=()
-    while IFS= read -r -d '' file; do
+    cache_scripts
+    
+    while IFS= read -r file; do
         category=$(dirname "$file" | xargs basename)
         script_name=$(basename "${file}" .sh)
         scripts+=("${category}/${script_name}")
-    done < <(find "$SCRIPT_DIR" -type f -name '*.sh' -print0)
+    done < "$SCRIPTS_CACHE_FILE"
+    
     scripts+=("Cancel")
 }
 
@@ -191,6 +306,13 @@ check_fzf() {
 search_scripts() {
     clear
     local direct_mode="$1"
+
+    local preview_cmd=""
+    local preview_window=""
+    if is_preview_enabled; then
+        preview_cmd="cat $SCRIPT_DIR/{}.sh 2>/dev/null | fold -w 70 || echo 'No preview available'"
+        preview_window="--preview-window=right:60%"
+    fi
     
     while true; do
         echo -e "\n${CYAN}Search Scripts: Press Esc To Exit${RESET}"
@@ -205,8 +327,8 @@ search_scripts() {
         
         selected_script=$(printf "%s\n" "${available_scripts[@]}" | fzf --height 50% --border \
                --prompt="Search scripts: " \
-               --preview="cat $SCRIPT_DIR/{}.sh 2>/dev/null | fold -w 70 || echo 'No preview available'" \
-               --preview-window=right:60%)
+               ${preview_cmd:+--preview="$preview_cmd"} \
+               ${preview_window})
         
         if [[ -n "$selected_script" ]]; then
             local full_script_path="$SCRIPT_DIR/${selected_script}.sh"
@@ -317,6 +439,13 @@ display_scripts_menu() {
     INSTALLED_VERSION=$(get_installed_version)
     TERM_WIDTH=$(tput cols)
 
+    local preview_cmd=""
+    local preview_window=""
+    if is_preview_enabled; then
+        preview_cmd="cat $SCRIPT_DIR/{}.sh 2>/dev/null | fold -w 70 || echo 'No preview available'"
+        preview_window="--preview-window=right:60%"
+    fi
+
     while true; do
         clear
         echo -e "${BLUE}╭$(printf '━%.0s' $(seq 1 $((TERM_WIDTH - 2))))╮${NC}"
@@ -360,8 +489,8 @@ display_scripts_menu() {
         selected_option=$(printf "%s\n" "${all_options[@]}" | fzf --height 60% --border \
             --prompt="Select a script: " \
             --header="Navigate with arrow keys, Enter to select" \
-            --preview="cat $SCRIPT_DIR/{}.sh 2>/dev/null | fold -w 70 || echo 'No preview available'" \
-            --preview-window=right:60%)
+            ${preview_cmd:+--preview="$preview_cmd"} \
+            ${preview_window})
         
         if [[ -z "$selected_option" ]]; then
             continue
@@ -380,17 +509,24 @@ run_script() {
     local category=$(dirname "$script_path")
     local script_name=$(basename "$script_path" .sh)
     local full_script_path="$SCRIPT_DIR/$script_path.sh"
+    local tmp_script_path="$TMP_DIR/${script_name}_$(date +%s).sh"
 
     if [[ -f "$full_script_path" ]]; then
         log_message "INFO" "Starting script: ${script_path}"
         echo -e "${YELLOW}Running script: ${script_path}${RESET}"
-        if bash "$full_script_path"; then
+        
+        cp "$full_script_path" "$tmp_script_path"
+        chmod +x "$tmp_script_path"
+        
+        if bash "$tmp_script_path"; then
             echo -e "${GREEN}Script '${script_path}' completed successfully.${RESET}"
             log_message "SUCCESS" "Script '${script_path}' completed successfully."
         else
             echo -e "${YELLOW}Script '${script_path}' encountered an error.${RESET}"
             log_message "ERROR" "Script '${script_path}' encountered an error."
         fi
+        
+        rm -f "$tmp_script_path"
     else
         echo -e "${YELLOW}Error: Script '${script_path}' not found!${RESET}"
         log_message "ERROR" "Script '${script_path}' not found."
@@ -405,17 +541,24 @@ run_script() {
 run_script_direct() {
     local script_path="$1"
     local full_script_path="$SCRIPT_DIR/$script_path.sh"
+    local tmp_script_path="$TMP_DIR/$(basename "$script_path")_$(date +%s).sh"
 
     if [[ -f "$full_script_path" ]]; then
         log_message "INFO" "Starting script: ${script_path}"
         echo -e "${YELLOW}Running script: ${script_path}${RESET}"
-        if bash "$full_script_path"; then
+        
+        cp "$full_script_path" "$tmp_script_path"
+        chmod +x "$tmp_script_path"
+        
+        if bash "$tmp_script_path"; then
             echo -e "${GREEN}Script '${script_path}' completed successfully.${RESET}"
             log_message "SUCCESS" "Script '${script_path}' completed successfully."
         else
             echo -e "${YELLOW}Script '${script_path}' encountered an error.${RESET}"
             log_message "ERROR" "Script '${script_path}' encountered an error."
         fi
+        
+        rm -f "$tmp_script_path"
     else
         echo -e "${YELLOW}Error: Script '${script_path}' not found!${RESET}"
         log_message "ERROR" "Script '${script_path}' not found."
@@ -445,8 +588,6 @@ update() {
 show_help() {
     echo -e "${CYAN}Usage: carch [OPTIONS]${RESET}"
     echo
-    echo -e "${YELLOW}A script for automating Linux setups.${RESET}"
-    echo
     echo -e "${CYAN}Options:${RESET}"
     echo -e "${YELLOW}  --help, -h              ${RESET}Show this help message and exit."
     echo -e "${YELLOW}  --version, -v           ${RESET}Show the program version."
@@ -456,6 +597,10 @@ show_help() {
     echo -e "${YELLOW}  --run-script <name>, -r ${RESET}Run the specified script from $SCRIPT_DIR."
     echo -e "${YELLOW}  --list-scripts, -l      ${RESET}List all available scripts in $SCRIPT_DIR."
     echo -e "${YELLOW}  --search, -s            ${RESET}Search for scripts by keyword."
+    echo -e "${YELLOW}  --no-preview            ${RESET}Run without displaying script previews in menus (one-time)."
+    echo -e "${YELLOW}  --disable-preview       ${RESET}Permanently disable script previews in menus."
+    echo -e "${YELLOW}  --log                   ${RESET}Enable logging for the current session only."
+    echo -e "${YELLOW}  --enable-logging        ${RESET}Permanently enable logging in the configuration file."
     echo -e "${YELLOW}  --update                ${RESET}Update Carch using the latest script."
     echo -e "${YELLOW}  --check-update          ${RESET}Check if a new version of Carch is available."
     echo -e "${YELLOW}  --uninstall             ${RESET}Uninstall Carch and remove all associated files."
@@ -539,6 +684,30 @@ if [[ $# -gt 0 ]]; then
         --search|-s)
             check_fzf
             search_scripts "direct"
+            ;;
+        --no-preview)
+            NO_PREVIEW="true"
+            shift
+            if [[ $# -gt 0 ]]; then
+                "$0" "$@"
+            else
+                display_scripts_menu
+            fi
+            ;;
+        --disable-preview)
+            disable_preview
+            ;;
+        --log)
+            LOG_MODE="true"
+            shift
+            if [[ $# -gt 0 ]]; then
+                "$0" "$@"
+            else
+                display_scripts_menu
+            fi
+            ;;
+        --enable-logging)
+            enable_logging
             ;;
         --check-update)
             check_carch_update


### PR DESCRIPTION
### Description

- Added a new command `--no-preview` to run Carch without showing script previews in the main menu.
- Added `--disable-preview`, which permanently disables script previews from the configuration file (`~/.config/carch/carch.conf`). You can edit this setting to enable or disable it.
- Added `--log`. Now, logging will only capture output if you use `carch --log`. If you run Carch without `--log`, logging will not capture output automatically.
- Added `--enable-logging`. This permanently enables logging, so you no longer need to use `--log` each time. With `--enable-logging`, logging will automatically be captured during normal Carch execution. This setting can also be edited in the Carch configuration file to enable or disable logging.
- Added performance improvements, especially when running scripts from the menu.
- Applied minor fixes and cleanup.

### Changes
- [ ] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [ ] Fixes. <!-- Fixes Scripts/Other -->
- [x] Feature <!-- Added -->
- [ ] UI/UX <!-- Enhancement -->
- [ ] Rust Code Update <!-- Updated or improved Rust-related code -->
- [ ] Rust Bug Fix <!-- Fixed Rust-related issues -->
- [ ] Rust Feature <!-- Added a new Rust-based feature -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [x] Tested on Fedora Linux.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

