### PR TITLE
Changelog v4.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,51 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+
+## [4.3.6](https://github.com/harilvfs/carch/compare/v4.3.5...v4.3.6) (2025-04-24)
+
+### Changed
+
+
+* chore: add gtk dependencies [`5c25cd9`](https://github.com/harilvfs/carch/commit/5c25cd9)
+* chore: add man pages dependencies [`9f1200f`](https://github.com/harilvfs/carch/commit/9f1200f)
+* chore: lefted dependencies [`adc6fe8`](https://github.com/harilvfs/carch/commit/adc6fe8)
+* chore: add some missing dependenceis [`f1d2a59`](https://github.com/harilvfs/carch/commit/f1d2a59)
+* chore: wayland dependencies [`72f36af`](https://github.com/harilvfs/carch/commit/72f36af)
+* refactor: cleanup & fix fall back npm [`632547b`](https://github.com/harilvfs/carch/commit/632547b)
+* chore: add papirus icon theme [`40affb7`](https://github.com/harilvfs/carch/commit/40affb7)
+* chore: add wayland dependencies needed [`fd5c699`](https://github.com/harilvfs/carch/commit/fd5c699)
+* chore: minor left over pacman [`be4c8f0`](https://github.com/harilvfs/carch/commit/be4c8f0)
+* chore: finally added gnome-keyring [`7c0d541`](https://github.com/harilvfs/carch/commit/7c0d541)
+* chore: add slock dependencies [`61c5cd8`](https://github.com/harilvfs/carch/commit/61c5cd8)
+
+### Added
+
+
+* feat: add install script by @harilvfs in https://github.com/harilvfs/carch/pull/413
+* feat: Added foot & ghostty setup script by @harilvfs in https://github.com/harilvfs/carch/pull/412
+* build(deps): bump crossterm from 0.26.1 to 0.29.0 by @dependabot in https://github.com/harilvfs/carch/pull/411
+* feat: add multi select in package script [`c547439`](https://github.com/harilvfs/carch/commit/c547439)
+* feat: add noto & dejavu fonts [`829ff41`](https://github.com/harilvfs/carch/commit/829ff41)
+* feat: add bluetooth setup script [`4079a3f`](https://github.com/harilvfs/carch/commit/4079a3f)
+* feat: add audio setup script [`8c6fe1e`](https://github.com/harilvfs/carch/commit/8c6fe1e)
+
+### Fixed
+
+
+* fix: tui in runnin tty env [`f1ff9ed`](https://github.com/harilvfs/carch/commit/f1ff9ed)
+* fix: minor fixes to script side [`d37131f`](https://github.com/harilvfs/carch/commit/d37131f)
+* fix: typos [`13ef0a1`](https://github.com/harilvfs/carch/commit/13ef0a1)
+* fix: chaotic aur failing [`30ff7da`](https://github.com/harilvfs/carch/commit/30ff7da)
+* fix: xinitrc calling & promt [`ce46c37`](https://github.com/harilvfs/carch/commit/ce46c37)
+* fix: color code in fish script [`b14af17`](https://github.com/harilvfs/carch/commit/b14af17)
+
+### Removed
+
+
+* remove: old command [`133ae7e`](https://github.com/harilvfs/carch/commit/133ae7e)
+* remove: cleanup old typo [`d15bcf4`](https://github.com/harilvfs/carch/commit/d15bcf4)
+
+For a detailed changelog, visit the [release section](https://github.com/harilvfs/carch/releases/tag/v4.3.6).
 
 ## [4.3.6](https://github.com/harilvfs/carch/compare/v4.3.5...v4.3.6) (2025-04-24)
 


### PR DESCRIPTION
PR to updates the CHANGELOG.md with the latest changes for version v4.3.6.

## Summary of changes:

```markdown
## [4.3.6](https://github.com/harilvfs/carch/compare/v4.3.5...v4.3.6) (2025-04-24)

### Changed


* chore: add gtk dependencies [`5c25cd9`](https://github.com/harilvfs/carch/commit/5c25cd9)
* chore: add man pages dependencies [`9f1200f`](https://github.com/harilvfs/carch/commit/9f1200f)
* chore: lefted dependencies [`adc6fe8`](https://github.com/harilvfs/carch/commit/adc6fe8)
* chore: add some missing dependenceis [`f1d2a59`](https://github.com/harilvfs/carch/commit/f1d2a59)
* chore: wayland dependencies [`72f36af`](https://github.com/harilvfs/carch/commit/72f36af)
* refactor: cleanup & fix fall back npm [`632547b`](https://github.com/harilvfs/carch/commit/632547b)
* chore: add papirus icon theme [`40affb7`](https://github.com/harilvfs/carch/commit/40affb7)
* chore: add wayland dependencies needed [`fd5c699`](https://github.com/harilvfs/carch/commit/fd5c699)
* chore: minor left over pacman [`be4c8f0`](https://github.com/harilvfs/carch/commit/be4c8f0)
* chore: finally added gnome-keyring [`7c0d541`](https://github.com/harilvfs/carch/commit/7c0d541)
* chore: add slock dependencies [`61c5cd8`](https://github.com/harilvfs/carch/commit/61c5cd8)

### Added


* feat: add install script by @harilvfs in https://github.com/harilvfs/carch/pull/413
* feat: Added foot & ghostty setup script by @harilvfs in https://github.com/harilvfs/carch/pull/412
* build(deps): bump crossterm from 0.26.1 to 0.29.0 by @dependabot in https://github.com/harilvfs/carch/pull/411
* feat: add multi select in package script [`c547439`](https://github.com/harilvfs/carch/commit/c547439)
* feat: add noto & dejavu fonts [`829ff41`](https://github.com/harilvfs/carch/commit/829ff41)
* feat: add bluetooth setup script [`4079a3f`](https://github.com/harilvfs/carch/commit/4079a3f)
* feat: add audio setup script [`8c6fe1e`](https://github.com/harilvfs/carch/commit/8c6fe1e)

### Fixed


* fix: tui in runnin tty env [`f1ff9ed`](https://github.com/harilvfs/carch/commit/f1ff9ed)
* fix: minor fixes to script side [`d37131f`](https://github.com/harilvfs/carch/commit/d37131f)
* fix: typos [`13ef0a1`](https://github.com/harilvfs/carch/commit/13ef0a1)
* fix: chaotic aur failing [`30ff7da`](https://github.com/harilvfs/carch/commit/30ff7da)
* fix: xinitrc calling & promt [`ce46c37`](https://github.com/harilvfs/carch/commit/ce46c37)
* fix: color code in fish script [`b14af17`](https://github.com/harilvfs/carch/commit/b14af17)

### Removed


* remove: old command [`133ae7e`](https://github.com/harilvfs/carch/commit/133ae7e)
* remove: cleanup old typo [`d15bcf4`](https://github.com/harilvfs/carch/commit/d15bcf4)

For a detailed changelog, visit the [release section](https://github.com/harilvfs/carch/releases/tag/v4.3.6).
```