### PR TITLE
chore: add eza for terminal scripts

### DIFF
--- a/src/modules/Terminal/Bash.sh
+++ b/src/modules/Terminal/Bash.sh
@@ -56,7 +56,6 @@ install_eza() {
             sudo pacman -S --noconfirm eza
             ;;
         fedora)
-            # due to eza is no longer available on fedora 42 installing manually
             echo -e "${CYAN}Installing eza manually for Fedora...${RESET}"
             local tmp_dir=$(mktemp -d)
             cd "$tmp_dir" || exit 1

--- a/src/modules/Terminal/Bash.sh
+++ b/src/modules/Terminal/Bash.sh
@@ -312,4 +312,3 @@ install_pokemon_colorscripts() {
 install_pokemon_colorscripts
 
 echo -e "${BLUE}Setup completed successfully!${RESET}"
-

--- a/src/modules/Terminal/Bash.sh
+++ b/src/modules/Terminal/Bash.sh
@@ -312,3 +312,4 @@ install_pokemon_colorscripts() {
 install_pokemon_colorscripts
 
 echo -e "${BLUE}Setup completed successfully!${RESET}"
+

--- a/src/modules/Terminal/Bash.sh
+++ b/src/modules/Terminal/Bash.sh
@@ -44,6 +44,56 @@ check_fzf() {
     fi
 }
 
+install_eza() {
+    if command -v eza &>/dev/null; then
+        echo -e "${GREEN}eza is already installed.${RESET}"
+        return 0
+    fi
+
+    echo -e "${CYAN}Installing eza...${RESET}"
+    case "$distro" in
+        arch)
+            sudo pacman -S --noconfirm eza
+            ;;
+        fedora)
+            # due to eza is no longer available on fedora 42 installing manually
+            echo -e "${CYAN}Installing eza manually for Fedora...${RESET}"
+            local tmp_dir=$(mktemp -d)
+            cd "$tmp_dir" || exit 1
+            echo -e "${CYAN}Fetching latest eza release...${RESET}"
+            local latest_url=$(curl -s https://api.github.com/repos/eza-community/eza/releases/latest | grep -o "https://github.com/eza-community/eza/releases/download/.*/eza_x86_64-unknown-linux-gnu.zip" | head -1)
+            if [ -z "$latest_url" ]; then
+                echo -e "${YELLOW}Could not determine latest version, using fallback version...${RESET}"
+                latest_url="https://github.com/eza-community/eza/releases/download/v0.21.1/eza_x86_64-unknown-linux-gnu.zip"
+            fi
+            echo -e "${CYAN}Downloading eza from: $latest_url${RESET}"
+            if ! curl -L -o eza.zip "$latest_url"; then
+                echo -e "${RED}Failed to download eza. Continuing without it...${RESET}"
+                cd "$HOME" || exit
+                rm -rf "$tmp_dir"
+                return 1
+            fi
+            echo -e "${CYAN}Extracting eza...${RESET}"
+            if ! unzip -q eza.zip; then
+                echo -e "${RED}Failed to extract eza. Continuing without it...${RESET}"
+                cd "$HOME" || exit
+                rm -rf "$tmp_dir"
+                return 1
+            fi
+            echo -e "${CYAN}Installing eza to /usr/bin...${RESET}"
+            sudo cp eza /usr/bin/
+            sudo chmod +x /usr/bin/eza
+            cd "$HOME" || exit
+            rm -rf "$tmp_dir"
+            echo -e "${GREEN}eza installed successfully!${RESET}"
+            ;;
+        *)
+            echo -e "${RED}Unsupported distribution for eza installation.${RESET}"
+            return 1
+            ;;
+    esac
+}
+
 clear
 
 RED="\033[1;31m"
@@ -91,6 +141,8 @@ case "$distro" in
     fedora) install_fedora ;;
     *) echo -e "${RED}Unsupported distribution.${RESET}"; exit 1 ;;
 esac
+
+install_eza
 
 options=("Catppuccin" "Nord" "Exit")
 THEME=$(printf "%s\n" "${options[@]}" | fzf ${FZF_COMMON} \


### PR DESCRIPTION
### Description

Since 'eza' is used in both your Fish and `.bashrc` profiles, we need to make sure it is installed on the system. I have used this logic from your zsh setup script.

### Changes
- [x] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [ ] Fixes. <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] UI/UX <!-- Enhancement -->
- [ ] Rust Code Update <!-- Updated or improved Rust-related code -->
- [ ] Rust Bug Fix <!-- Fixed Rust-related issues -->
- [ ] Rust Feature <!-- Added a new Rust-based feature -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [x] Tested on Fedora Linux.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
