### PR TITLE
feat: exit early if fzf is not installed

### DIFF
--- a/src/modules/Desktop/Dunst.sh
+++ b/src/modules/Desktop/Dunst.sh
@@ -6,6 +6,8 @@ BLUE="\e[34m"
 RESET="\e[0m"
 RED="\e[31m"
 GREEN="\e[32m"
+YELLOW='\033[33m'
+CYAN='\033[36m'
 
 FZF_COMMON="--layout=reverse \
             --border=bold \
@@ -40,6 +42,14 @@ print_message() {
 }
 
 clear
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 if ! command -v dunst &>/dev/null; then
     print_message "$BLUE" "Dunst not found. Installing..."

--- a/src/modules/Desktop/Dwm.sh
+++ b/src/modules/Desktop/Dwm.sh
@@ -319,6 +319,14 @@ check_display_manager() {
     fi
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 detect_distro
 install_packages
 install_dwm

--- a/src/modules/Desktop/Hyprland.sh
+++ b/src/modules/Desktop/Hyprland.sh
@@ -6,8 +6,16 @@ BLUE='\033[0;34m'
 YELLOW='\033[0;33m'
 RED='\033[0;31m'
 RESET='\033[0m'
+YELLOW='\033[33m'
+CYAN='\033[36m'
 
-type fzf &>/dev/null || { echo "fzf is not installed. Install it first."; exit 1; }
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 FZF_COMMON="--layout=reverse \
             --border=bold \

--- a/src/modules/Desktop/Picom.sh
+++ b/src/modules/Desktop/Picom.sh
@@ -9,13 +9,8 @@ GREEN="\e[32m"
 RED="\e[31m"
 BLUE="\e[34m"
 YELLOW="\e[33m"
+CYAN='\033[36m'
 ENDCOLOR="\e[0m"
-
-echo -e "${GREEN}"
-cat << "EOF"
-Picom is a standalone compositor for Xorg.
-EOF
-echo -e "${ENDCOLOR}"
 
 FZF_COMMON="--layout=reverse \
             --border=bold \
@@ -138,7 +133,14 @@ download_config() {
     wget -O "$config_path" "$config_url"
 }
 
-# Start
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 detect_package_manager
 print_source_message
 

--- a/src/modules/Desktop/Rofi.sh
+++ b/src/modules/Desktop/Rofi.sh
@@ -11,6 +11,14 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 ENDCOLOR="\e[0m"
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 echo -e "${YELLOW}:: Note: JetBrains Mono Nerd Font is required for proper Rofi display. Please install it before continuing.${ENDCOLOR}"
 
 FZF_COMMON="--layout=reverse \

--- a/src/modules/Desktop/SwayWM.sh
+++ b/src/modules/Desktop/SwayWM.sh
@@ -211,6 +211,14 @@ manage_themes_icons() {
     git clone "$repo_url" "$target_dir/$repo_name"
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 print_message $BLUE "If the setup fails, please manually use the dotfiles from:
 https://github.com/harilvfs/swaydotfiles"
 

--- a/src/modules/Desktop/Themes-Icons.sh
+++ b/src/modules/Desktop/Themes-Icons.sh
@@ -80,6 +80,14 @@ install_dependencies() {
     echo -e "${GREEN}:: Dependencies installed successfully.${RESET}"
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 option=$(printf "Themes\nIcons\nBoth\nExit" | fzf ${FZF_COMMON} \
                                               --height=40% \
                                               --prompt="Choose an option: " \

--- a/src/modules/Desktop/Wallpapers.sh
+++ b/src/modules/Desktop/Wallpapers.sh
@@ -5,6 +5,8 @@
 clear
 
 GREEN='\033[0;32m'
+RED="\e[31m"
+YELLOW='\033[33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
@@ -36,6 +38,14 @@ fzf_confirm() {
 
 PICTURES_DIR="$HOME/Pictures"
 WALLPAPERS_DIR="$PICTURES_DIR/wallpapers"
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 echo -e "${CYAN}:: Wallpapers will be set up in the Pictures directory (${PICTURES_DIR}).${NC}"
 

--- a/src/modules/Desktop/i3wm.sh
+++ b/src/modules/Desktop/i3wm.sh
@@ -91,6 +91,14 @@ fzf_config_confirm() {
     esac
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 echo -e "${YELLOW}Warning: If you are re-running this script, Remember to remove the .i3wmdotfiles directory in your home directory to avoid any conflicts..${ENDCOLOR}"
 
 if command -v pacman &>/dev/null; then

--- a/src/modules/Development/Bun.sh
+++ b/src/modules/Development/Bun.sh
@@ -7,6 +7,7 @@ clear
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
+CYAN='\033[36m'
 RESET='\033[0m'
 
 FZF_COMMON="--layout=reverse \
@@ -19,14 +20,13 @@ FZF_COMMON="--layout=reverse \
             --bind change:top"
 
 check_fzf() {
-    if ! command -v fzf &>/dev/null; then
-        echo -e "${YELLOW}Installing fzf...${RESET}"
-        if command -v pacman &>/dev/null; then
-            sudo pacman -S --noconfirm fzf
-        elif command -v dnf &>/dev/null; then
-            sudo dnf install -y fzf
-        fi
-    fi
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 }
 
 install_bun() {

--- a/src/modules/Development/Helix.sh
+++ b/src/modules/Development/Helix.sh
@@ -5,6 +5,7 @@
 clear
 
 RED="\033[1;31m"
+YELLOW='\033[33m'
 GREEN="\033[1;32m"
 CYAN="\033[1;36m"
 RESET="\033[0m"
@@ -35,8 +36,11 @@ fzf_confirm() {
     fi
 }
 
-if ! command -v fzf &>/dev/null; then
-    echo -e "${RED}fzf is required but not installed. Please install it first.${RESET}"
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
     exit 1
 fi
 

--- a/src/modules/Development/Neovim.sh
+++ b/src/modules/Development/Neovim.sh
@@ -8,7 +8,16 @@ GREEN="\e[32m"
 RED="\e[31m"
 BLUE="\e[34m"
 YELLOW="\e[33m"
+CYAN='\033[36m'
 RESET="\e[0m"
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 echo -e "${BLUE}"
 cat <<"EOF"

--- a/src/modules/Development/Npm.sh
+++ b/src/modules/Development/Npm.sh
@@ -8,11 +8,14 @@ RED="\e[31m"
 GREEN="\e[32m"
 YELLOW="\e[33m"
 BLUE="\e[34m"
+CYAN='\033[36m'
 RESET="\e[0m"
 
-if ! command -v fzf &>/dev/null; then
-    echo -e "${RED}Error: 'fzf' is required for this script.${RESET}"
-    echo -e "${YELLOW}Please install 'fzf' before running this script.${RESET}"
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
     exit 1
 fi
 

--- a/src/modules/System/Audio.sh
+++ b/src/modules/System/Audio.sh
@@ -5,6 +5,7 @@
 clear
 
 GREEN="\e[32m"
+YELLOW='\033[33m'
 BLUE="\e[34m"
 RED="\e[31m"
 CYAN="\e[36m"
@@ -131,6 +132,14 @@ setup_user_and_services() {
 }
 
 main() {
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
+    fi
+
     detect_distro
     if fzf_confirm "Do you want to install PipeWire audio system?"; then
         install_pipewire

--- a/src/modules/System/Aur.sh
+++ b/src/modules/System/Aur.sh
@@ -21,67 +21,36 @@ detect_distro() {
 }
 
 check_dependencies() {
-    local missing_deps=()
+if ! command -v fzf &> /dev/null || ! command -v git &> /dev/null || ! command -v make &> /dev/null || ! command -v less &> /dev/null; then
 
-    echo -e "${CYAN}:: Checking for required dependencies...${NC}"
+    echo -e "${RED}${BOLD}Error: Required command(s) not found${NC}"
 
-    if ! command -v git &>/dev/null; then
-        missing_deps+=("git")
-    else
-        echo -e "${GREEN}✓ Git is installed${NC}"
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${YELLOW}- fzf is not installed.${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
     fi
 
-    if ! command -v make &>/dev/null; then
-        missing_deps+=("make")
-    else
-        echo -e "${GREEN}✓ Make is installed${NC}"
+    if ! command -v git &> /dev/null; then
+        echo -e "${YELLOW}- git is not installed.${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install git"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S git"
     fi
 
-    if ! command -v less &>/dev/null; then
-        missing_deps+=("less")
-    else
-        echo -e "${GREEN}✓ Less is installed${NC}"
+    if ! command -v make &> /dev/null; then
+        echo -e "${YELLOW}- make is not installed.${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install make"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S base-devel"
     fi
 
-    if ! command -v fzf &>/dev/null; then
-        missing_deps+=("fzf")
-    else
-        echo -e "${GREEN}✓ Fzf is installed${NC}"
+    if ! command -v less &> /dev/null; then
+        echo -e "${YELLOW}- less is not installed.${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install less"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S less"
     fi
 
-    if [ ${#missing_deps[@]} -gt 0 ]; then
-        echo -e "${YELLOW}The following dependencies need to be installed: ${missing_deps[*]}${NC}"
-
-        read -p "Install missing dependencies? [Y/n] " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then
-            echo -e "${RED}Cannot proceed without required dependencies. Exiting...${NC}"
-            read -p "Press Enter to continue..."
-            return 1
-        fi
-
-        echo -e "${CYAN}:: Installing missing dependencies...${NC}"
-        sudo pacman -S --needed "${missing_deps[@]}"
-
-        local failed=false
-        for dep in "${missing_deps[@]}"; do
-            if ! command -v "$dep" &>/dev/null; then
-                echo -e "${RED}Failed to install $dep${NC}"
-                failed=true
-            else
-                echo -e "${GREEN}✓ $dep installed successfully${NC}"
-            fi
-        done
-
-        if $failed; then
-            echo -e "${RED}Some dependencies failed to install. Cannot proceed.${NC}"
-            read -p "Press Enter to continue..."
-            return 1
-        fi
-    fi
-
-    echo -e "${GREEN}All required dependencies are installed.${NC}"
-    return 0
+    exit 1
+  fi
 }
 
 install_paru() {
@@ -203,6 +172,7 @@ FZF_COMMON="--layout=reverse \
 
 while true; do
     clear
+    check_dependencies
     echo -e "${CYAN}:: AUR Setup Menu [ For Arch Only ]${NC}"
     echo
 

--- a/src/modules/System/Bluetooth.sh
+++ b/src/modules/System/Bluetooth.sh
@@ -5,6 +5,7 @@
 clear
 
 GREEN="\e[32m"
+YELLOW='\033[33m'
 BLUE="\e[34m"
 RED="\e[31m"
 CYAN="\e[36m"
@@ -92,6 +93,15 @@ provide_additional_info() {
 }
 
 main() {
+
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
+    fi
+
     detect_distro
 
     if fzf_confirm "Do you want to install Bluetooth system?"; then

--- a/src/modules/System/Brightness.sh
+++ b/src/modules/System/Brightness.sh
@@ -178,6 +178,15 @@ set_specific_brightness() {
 }
 
 main() {
+
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
+    fi
+
     check_brightnessctl
 
     while true; do

--- a/src/modules/System/Fastfetch.sh
+++ b/src/modules/System/Fastfetch.sh
@@ -11,6 +11,14 @@ NC='\033[0m'
 BLUE="\e[34m"
 YELLOW="\e[33m"
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 echo -e "${BLUE}"
 cat <<"EOF"
 
@@ -157,7 +165,6 @@ setup_png_fastfetch() {
 
 main() {
     check_command git || { echo -e "${RED}Please install git and try again.${NC}"; exit 1; }
-    check_command fzf || { echo -e "${RED}Please install fzf and try again.${NC}"; exit 1; }
 
     clear
 

--- a/src/modules/System/Fonts.sh
+++ b/src/modules/System/Fonts.sh
@@ -5,9 +5,10 @@
 clear
 
 GREEN='\033[0;32m'
-CYAN='\033[0;36m'
 RED='\033[0;31m'
+CYAN='\033[0;36m'
 NC='\033[0m'
+YELLOW="\e[33m"
 
 FONTS_DIR="$HOME/.fonts"
 
@@ -194,6 +195,13 @@ detect_os() {
 }
 
 main() {
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
+    fi
     check_dependencies
     detect_os
     choose_fonts

--- a/src/modules/System/Grub.sh
+++ b/src/modules/System/Grub.sh
@@ -6,6 +6,8 @@ clear
 
 GREEN="\e[32m"
 BLUE="\e[34m"
+YELLOW='\033[33m'
+CYAN='\033[36m'
 RED="\e[31m"
 ENDCOLOR="\e[0m"
 
@@ -65,6 +67,14 @@ install_theme() {
     cd "$GRUB_THEME_DIR" || exit
     sudo ./install.sh
 }
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 print_message
 

--- a/src/modules/System/LTS-Kernel.sh
+++ b/src/modules/System/LTS-Kernel.sh
@@ -5,6 +5,7 @@
 clear
 
 GREEN="\e[32m"
+YELLOW='\033[33m'
 RED="\e[31m"
 BLUE="\e[34m"
 CYAN="\e[36m"
@@ -61,6 +62,14 @@ configure_grub() {
     echo -e "${GREEN}:: Updating GRUB configuration...${ENDCOLOR}"
     sudo grub-mkconfig -o /boot/grub/grub.cfg
 }
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 check_current_kernel
 

--- a/src/modules/System/Packages.sh
+++ b/src/modules/System/Packages.sh
@@ -5,6 +5,7 @@
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
+CYAN='\033[36m'
 RESET='\033[0m'
 
 FZF_COMMON="--layout=reverse \
@@ -2016,7 +2017,16 @@ install_crypto_tools() {
 }
 
 while true; do
+
     clear
+
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
+    fi
 
     options=("Android Tools" "Browsers" "Communication Apps" "Development Tools" "Editing Tools" "File Managers" "FM Tools" "Gaming" "GitHub" "Multimedia" "Music Apps" "Productivity Apps" "Streaming Tools" "Terminals" "Text Editors" "Virtualization" "Crypto Tools" "Exit")
     selected=$(printf "%s\n" "${options[@]}" | fzf ${FZF_COMMON} \

--- a/src/modules/System/Sddm.sh
+++ b/src/modules/System/Sddm.sh
@@ -6,7 +6,9 @@ clear
 
 export RED="\e[31m"
 export GREEN="\e[32m"
+export YELLOW="\033[33m"
 export BLUE="\e[34m"
+export CYAN="\033[36m"
 export ENDCOLOR="\e[0m"
 
 FZF_COMMON="--layout=reverse \
@@ -130,6 +132,14 @@ Current=catppuccin-mocha
 #
 EOF'
 }
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 print_banner
 detect_os

--- a/src/modules/Terminal/Alacritty.sh
+++ b/src/modules/Terminal/Alacritty.sh
@@ -79,6 +79,14 @@ setupAlacrittyConfig() {
     echo -e "${GREEN}:: Alacritty configuration files copied and migrated.${RESET}"
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 installAlacritty
 setupAlacrittyConfig
 

--- a/src/modules/Terminal/Bash.sh
+++ b/src/modules/Terminal/Bash.sh
@@ -34,13 +34,12 @@ check_essential_dependencies() {
 }
 
 check_fzf() {
-    if ! command -v fzf &>/dev/null; then
-        echo -e "${CYAN}Installing fzf...${RESET}"
-        case "$distro" in
-            arch) sudo pacman -S --noconfirm fzf ;;
-            fedora) sudo dnf install -y fzf ;;
-            *) echo -e "${RED}Unsupported distribution.${RESET}"; exit 1 ;;
-        esac
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
     fi
 }
 
@@ -137,11 +136,11 @@ FZF_COMMON="--layout=reverse \
             --header-first \
             --bind change:top"
 
-echo -e "${BLUE}Nerd Font Are Recommended${RESET}"
-
 detect_distro
 check_essential_dependencies
 check_fzf
+
+echo -e "${BLUE}Nerd Font Are Recommended${RESET}"
 
 echo -e "${CYAN}Detected distribution: $distro${RESET}"
 

--- a/src/modules/Terminal/Fish.sh
+++ b/src/modules/Terminal/Fish.sh
@@ -5,6 +5,7 @@
 clear
 
 GREEN="\033[0;32m"
+YELLOW='\033[33m'
 CYAN="\033[0;36m"
 RED="\033[0;31m"
 RESET="\033[0m"
@@ -104,6 +105,14 @@ install_zoxide() {
         exit 1
     fi
 }
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 detect_distro
 

--- a/src/modules/Terminal/Foot.sh
+++ b/src/modules/Terminal/Foot.sh
@@ -37,6 +37,14 @@ fzf_confirm() {
     fi
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 echo -e "${YELLOW}NOTE: This foot configuration uses Fish shell by default.${RESET}"
 echo -e "${YELLOW}If you're using Bash or Zsh, make sure to change it in ~/.config/foot/foot.ini${RESET}"
 echo -e "${YELLOW}Also, JetBrains Mono Nerd Font is required for this configuration.${RESET}"

--- a/src/modules/Terminal/Ghostty.sh
+++ b/src/modules/Terminal/Ghostty.sh
@@ -37,6 +37,14 @@ fzf_confirm() {
     fi
 }
 
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
+
 echo -e "${YELLOW}NOTE: This Ghostty configuration uses JetBrains Mono Nerd Font by default.${RESET}"
 echo -e "${YELLOW}You can change themes and other settings in ~/.config/ghostty/config${RESET}"
 echo -e "${YELLOW}For more configuration options, check the Ghostty docs at: https://ghostty.org/docs${RESET}"

--- a/src/modules/Terminal/Kitty.sh
+++ b/src/modules/Terminal/Kitty.sh
@@ -5,6 +5,7 @@
 clear
 
 GREEN='\033[0;32m'
+YELLOW='\033[33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 RED='\033[0;31m'
@@ -93,6 +94,14 @@ install_font() {
         echo -e "${CYAN}Skipping font installation.${NC}"
     fi
 }
+
+if ! command -v fzf &> /dev/null; then
+    echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+    echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+    echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+    echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+    exit 1
+fi
 
 setup_kitty
 install_font

--- a/src/modules/Terminal/Zsh.sh
+++ b/src/modules/Terminal/Zsh.sh
@@ -95,14 +95,13 @@ detect_distro() {
     print_message "$CYAN" "Detected distribution: $DISTRO"
 }
 
-install_fzf() {
-    if ! command -v fzf &>/dev/null; then
-        print_message "$CYAN" "Installing fzf..."
-        if command -v pacman &>/dev/null; then
-            sudo pacman -S --noconfirm fzf
-        elif command -v dnf &>/dev/null; then
-            sudo dnf install -y fzf
-        fi
+check_fzf() {
+    if ! command -v fzf &> /dev/null; then
+        echo -e "${RED}${BOLD}Error: fzf is not installed${NC}"
+        echo -e "${YELLOW}Please install fzf before running this script:${NC}"
+        echo -e "${CYAN}  • Fedora: ${NC}sudo dnf install fzf"
+        echo -e "${CYAN}  • Arch Linux: ${NC}sudo pacman -S fzf"
+        exit 1
     fi
 }
 
@@ -134,11 +133,11 @@ check_default_shell() {
 
 clear
 
+check_fzf
+
 detect_distro
 
 check_essential_dependencies
-
-install_fzf
 
 if command -v pacman &> /dev/null; then
     check_aur_helper


### PR DESCRIPTION
### Description

If the user runs Carch from the repo, it's usually fine. But if `fzf` is not installed, the script can act weird in some cases. So, I added a check to stop the script right away if `fzf` is missing.

### Changes
- [ ] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [x] Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [x] UI/UX <!-- Enhancement -->
- [ ] Rust Code Update <!-- Updated or improved Rust-related code -->
- [ ] Rust Bug Fix <!-- Fixed Rust-related issues -->
- [ ] Rust Feature <!-- Added a new Rust-based feature -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->
- [ ] Documentation <!-- changes related to the readme.md or any other markdown files -->

### How Has This Been Tested?

<!-- Describe the steps you followed to test the changes. If applicable, mention the specific environment where the testing took place. -->
- [x] Tested on Arch Linux/Based Distro.
- [x] Tested on Fedora Linux/Based Distro.

### Checklist

Please ensure your pull request meets the following requirements:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
