### PR TITLE
docs(readme): add catppuccin footer

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,7 @@ It’s especially useful if you want to quickly set up and start using your *fav
 For more, see the [documentation](https://carch.chalisehari.com.np). You can also join us on [Discord](https://discord.com/invite/8NJWstnUHd) or [Telegram](https://t.me/carchx) for help and discussions.
 
 <!-- Catppuccin Footer -->
-<!-- Source: https://github.com/catppuccin/catppuccin/blob/main/assets/footers/gray0_ctp_on_line.svg -->
+<!-- Source: https://github.com/catppuccin/catppuccin -->
 
 <p align="center">
 	<img src="https://raw.githubusercontent.com/harilvfs/assets/refs/heads/main/carch/catppuccin-footer.svg" />

--- a/.github/README.md
+++ b/.github/README.md
@@ -26,7 +26,7 @@ For more, see the [documentation](https://carch.chalisehari.com.np). You can als
 <!-- Source: https://github.com/catppuccin/catppuccin/blob/main/assets/footers/gray0_ctp_on_line.svg -->
 
 <p align="center">
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" />
+	<img src="https://raw.githubusercontent.com/harilvfs/assets/refs/heads/main/carch/catppuccin-footer.svg" />
 </p>
 
 <!-- Badges -->

--- a/.github/README.md
+++ b/.github/README.md
@@ -22,6 +22,13 @@ It’s especially useful if you want to quickly set up and start using your *fav
 
 For more, see the [documentation](https://carch.chalisehari.com.np). You can also join us on [Discord](https://discord.com/invite/8NJWstnUHd) or [Telegram](https://t.me/carchx) for help and discussions.
 
+<!-- Catppuccin Footer -->
+<!-- Source: https://github.com/catppuccin/catppuccin/blob/main/assets/footers/gray0_ctp_on_line.svg -->
+
+<p align="center">
+	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" />
+</p>
+
 <!-- Badges -->
 
 [ratatui]: https://ratatui.rs/built-with-ratatui/badge.svg


### PR DESCRIPTION
### Description

Now Carch has the Catppuccin theme by default in the TUI, so we can officially add the Catppuccin footer to the README. Jokes aside, it looks nice here.

### Changes
- [ ] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [ ] Improved <!-- optimized existing functionality -->
- [ ] Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] UI/UX <!-- Enhancement -->
- [ ] Rust Code Update <!-- Updated or improved Rust-related code -->
- [ ] Rust Bug Fix <!-- Fixed Rust-related issues -->
- [ ] Rust Feature <!-- Added a new Rust-based feature -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->
- [x] Documentation <!-- changes related to the readme.md or any other markdown files -->

### Context

IDK it just looks cool.

### Screenshots 

<img width="991" height="130" alt="footer" src="https://github.com/user-attachments/assets/080a9390-2419-417d-821b-3bd6d5a79fc9" />
