### PR TITLE
refactor(commands): re-write update/uninstall in rust

### DIFF
--- a/carch-cli/src/commands.rs
+++ b/carch-cli/src/commands.rs
@@ -2,7 +2,6 @@ use carch_core::error::{CarchError, Result};
 use log::info;
 use std::fs;
 use std::io::{self, Write};
-use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Stdio};
 use tempfile::Builder;
 
@@ -34,11 +33,45 @@ pub fn check_for_updates() -> Result<()> {
     Ok(())
 }
 
-enum InstallMethod {
-    Cargo,
-    PackageManager,
-    Exit,
-    Invalid,
+enum Distro {
+    Termux,
+    Arch,
+    Fedora,
+    OpenSuse,
+}
+
+fn is_termux() -> bool {
+    std::env::var("TERMUX_VERSION").is_ok()
+        || std::path::Path::new("/data/data/com.termux").exists()
+}
+
+fn detect_distro() -> Result<Distro> {
+    if is_termux() {
+        return Ok(Distro::Termux);
+    }
+    if command_exists("pacman") {
+        return Ok(Distro::Arch);
+    }
+    if command_exists("dnf") {
+        return Ok(Distro::Fedora);
+    }
+    if command_exists("zypper") {
+        return Ok(Distro::OpenSuse);
+    }
+    Err(CarchError::Command(
+        "Unsupported distribution. Carch supports Arch, Fedora, openSUSE, and Termux.".into(),
+    ))
+}
+
+fn detect_termux_arch() -> Result<&'static str> {
+    let out = Command::new("uname").arg("-m").output()?;
+    let arch = String::from_utf8_lossy(&out.stdout);
+    let arch = arch.trim();
+    match arch {
+        "aarch64" | "arm64" => Ok("aarch64"),
+        a if a.starts_with("armv7") || a == "armv8l" || a == "arm" => Ok("arm"),
+        other => Err(CarchError::Command(format!("Unsupported Termux architecture: {other}"))),
+    }
 }
 
 fn command_exists(command: &str) -> bool {
@@ -59,38 +92,163 @@ fn run_command(command: &mut Command) -> Result<()> {
     Ok(())
 }
 
-fn get_installation_method() -> Result<InstallMethod> {
-    print!(
-        "From which install media have you installed carch? (c)argo, (p)ackage manager, or (e)xit: "
-    );
+fn get_latest_release_url(asset_pattern: &str) -> Result<String> {
+    let client = reqwest::blocking::Client::new();
+    let body = client
+        .get("https://api.github.com/repos/harilvfs/carch/releases/latest")
+        .header("User-Agent", "carch-cli")
+        .send()?
+        .text()?;
+
+    for line in body.lines() {
+        if !line.contains("browser_download_url") {
+            continue;
+        }
+        for token in line.split('"') {
+            if token.starts_with("https://") && token.ends_with(asset_pattern) {
+                return Ok(token.to_string());
+            }
+        }
+    }
+
+    Err(CarchError::Command(format!("Could not find release asset matching '{asset_pattern}'")))
+}
+
+fn get_rpm_url() -> Result<String> {
+    get_latest_release_url(".rpm")
+}
+
+fn termux_install_deb(deb_arch: &str) -> Result<()> {
+    println!("==> Fetching latest .deb package for {deb_arch}...");
+
+    let pattern = format!("_{deb_arch}.deb");
+    let deb_url = get_latest_release_url(&pattern)?;
+
+    let tmp_dir =
+        std::env::var("PREFIX").map(|p| format!("{p}/tmp")).unwrap_or_else(|_| "/tmp".into());
+
+    let mut tmp_deb = Builder::new().prefix("carch_").suffix(".deb").tempfile_in(&tmp_dir)?;
+
+    println!("==> Downloading .deb package...");
+    let bytes = reqwest::blocking::get(&deb_url)?.bytes()?;
+    tmp_deb.write_all(&bytes)?;
+
+    let tmp_path = tmp_deb.path().to_path_buf();
+
+    println!("==> Installing .deb package...");
+    run_command(Command::new("dpkg").arg("-i").arg(&tmp_path))?;
+
+    fs::remove_file(&tmp_path).ok();
+    Ok(())
+}
+
+fn install_for_distro(distro: &Distro) -> Result<()> {
+    match distro {
+        Distro::Termux => {
+            let arch = detect_termux_arch()?;
+            println!("==> Detected Termux architecture: {arch}");
+            termux_install_deb(arch)
+        }
+        Distro::Arch => {
+            println!("==> Cloning PKGBUILD...");
+            let home = std::env::var("HOME")
+                .map_err(|_| CarchError::Command("$HOME is not set".into()))?;
+            let pkgs_dir = std::path::PathBuf::from(home).join("pkgs");
+
+            if pkgs_dir.exists() {
+                fs::remove_dir_all(&pkgs_dir)?;
+            }
+
+            run_command(
+                Command::new("git")
+                    .arg("clone")
+                    .arg("https://github.com/carch-org/pkgs")
+                    .arg(&pkgs_dir)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null()),
+            )?;
+
+            let carch_bin_dir = pkgs_dir.join("carch-bin");
+            run_command(
+                Command::new("makepkg").arg("-si").arg("--noconfirm").current_dir(&carch_bin_dir),
+            )
+        }
+        Distro::Fedora | Distro::OpenSuse => {
+            println!("==> Downloading carch RPM...");
+            let rpm_url = get_rpm_url()?;
+
+            let bytes = reqwest::blocking::get(&rpm_url)?.bytes()?;
+            let rpm_path = std::path::PathBuf::from("/tmp/carch.rpm");
+            fs::write(&rpm_path, &bytes)?;
+
+            match distro {
+                Distro::Fedora => run_command(
+                    Command::new("sudo").arg("dnf").arg("install").arg("-y").arg(&rpm_path),
+                ),
+                Distro::OpenSuse => run_command(
+                    Command::new("sudo")
+                        .arg("zypper")
+                        .arg("install")
+                        .arg("-y")
+                        .arg("--allow-unsigned-rpm")
+                        .arg(&rpm_path),
+                ),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+fn uninstall_for_distro(distro: &Distro) -> Result<()> {
+    match distro {
+        Distro::Termux => {
+            let installed = Command::new("dpkg")
+                .args(["-s", "carch"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|s| s.success());
+
+            if installed {
+                run_command(Command::new("dpkg").arg("-r").arg("carch"))?;
+                println!("==> carch has been removed.");
+            } else {
+                println!("==> carch is not installed.");
+            }
+            Ok(())
+        }
+        Distro::Arch => run_command(
+            Command::new("sudo")
+                .arg("pacman")
+                .arg("-R")
+                .arg("carch-bin")
+                .arg("carch-bin-debug")
+                .arg("--noconfirm"),
+        ),
+        Distro::Fedora => {
+            run_command(Command::new("sudo").arg("dnf").arg("remove").arg("carch").arg("-y"))
+        }
+        Distro::OpenSuse => {
+            run_command(Command::new("sudo").arg("zypper").arg("remove").arg("-y").arg("carch"))
+        }
+    }
+}
+
+enum InstallMethod {
+    Cargo,
+    PackageManager,
+}
+
+fn get_install_method() -> Result<InstallMethod> {
+    print!("Installed via (c)argo or (p)ackage manager? ");
     io::stdout().flush()?;
     let mut choice = String::new();
     io::stdin().read_line(&mut choice)?;
-    Ok(match choice.trim().to_lowercase().as_str() {
-        "c" | "cargo" => InstallMethod::Cargo,
-        "p" | "package manager" => InstallMethod::PackageManager,
-        "e" | "exit" => InstallMethod::Exit,
-        _ => InstallMethod::Invalid,
-    })
-}
-
-fn run_script_from_url(action: &str) -> Result<()> {
-    info!("Downloading install script...");
-    let script_contents =
-        reqwest::blocking::get("https://chalisehari.com.np/carchinstall")?.bytes()?;
-
-    let mut temp_script = Builder::new().prefix("carch-install-").suffix(".sh").tempfile()?;
-    temp_script.write_all(&script_contents)?;
-
-    let temp_path = temp_script.path().to_path_buf();
-    let mut perms = fs::metadata(&temp_path)?.permissions();
-    perms.set_mode(0o755); // rwxr-xr-x
-    fs::set_permissions(&temp_path, perms)?;
-
-    info!("Executing install script with action: {action}");
-    run_command(Command::new("sh").arg(&temp_path).arg(action))?;
-
-    Ok(())
+    match choice.trim().to_lowercase().as_str() {
+        "c" | "cargo" => Ok(InstallMethod::Cargo),
+        "p" | "package manager" => Ok(InstallMethod::PackageManager),
+        _ => Err(CarchError::Command("Invalid choice. Please run the command again.".into())),
+    }
 }
 
 pub fn update() -> Result<()> {
@@ -99,30 +257,19 @@ pub fn update() -> Result<()> {
         return Ok(());
     }
 
-    match get_installation_method()? {
-        InstallMethod::Cargo => update_via_cargo(),
-        InstallMethod::PackageManager => update_via_package_manager(),
-        InstallMethod::Exit => {
-            println!("Exiting update.");
-            Ok(())
+    info!("Starting update...");
+    println!("==> Updating carch...");
+
+    match get_install_method()? {
+        InstallMethod::Cargo => {
+            run_command(Command::new("cargo").arg("install").arg("carch-cli").arg("--force"))?;
         }
-        InstallMethod::Invalid => {
-            println!("Invalid choice. Please run the command again.");
-            Ok(())
+        InstallMethod::PackageManager => {
+            let distro = detect_distro()?;
+            install_for_distro(&distro)?;
         }
     }
-}
 
-fn update_via_cargo() -> Result<()> {
-    info!("Updating via cargo...");
-    run_command(Command::new("cargo").arg("install").arg("carch-cli").arg("--force"))?;
-    println!("Update done.");
-    Ok(())
-}
-
-fn update_via_package_manager() -> Result<()> {
-    info!("Updating via install script...");
-    run_script_from_url("update")?;
     println!("Update done.");
     Ok(())
 }
@@ -133,30 +280,18 @@ pub fn uninstall() -> Result<()> {
         return Ok(());
     }
 
-    match get_installation_method()? {
-        InstallMethod::Cargo => uninstall_via_cargo(),
-        InstallMethod::PackageManager => uninstall_via_package_manager(),
-        InstallMethod::Exit => {
-            println!("Exiting uninstallation.");
-            Ok(())
+    info!("Starting uninstall...");
+
+    match get_install_method()? {
+        InstallMethod::Cargo => {
+            run_command(Command::new("cargo").arg("uninstall").arg("carch-cli"))?;
         }
-        InstallMethod::Invalid => {
-            println!("Invalid choice. Please run the command again.");
-            Ok(())
+        InstallMethod::PackageManager => {
+            let distro = detect_distro()?;
+            uninstall_for_distro(&distro)?;
         }
     }
-}
 
-fn uninstall_via_cargo() -> Result<()> {
-    info!("Uninstalling via cargo...");
-    run_command(Command::new("cargo").arg("uninstall").arg("carch-cli"))?;
-    println!("Uninstallation done.");
-    Ok(())
-}
-
-fn uninstall_via_package_manager() -> Result<()> {
-    info!("Uninstalling via install script...");
-    run_script_from_url("uninstall")?;
     println!("Uninstallation done.");
     Ok(())
 }

--- a/install.sh
+++ b/install.sh
@@ -5,14 +5,6 @@ GREEN='\033[1;32m'
 RED='\033[1;31m'
 NC='\033[0m'
 
-show_usage() {
-    printf "Usage: carch [install|uninstall|update]\n"
-    printf "  install   - Install carch (default)\n"
-    printf "  uninstall - Remove carch from system\n"
-    printf "  update    - Update carch to latest version\n"
-    exit 1
-}
-
 is_termux() {
     [ -n "$TERMUX_VERSION" ] ||
         [ -d "/data/data/com.termux" ] ||
@@ -119,38 +111,7 @@ install_rpm() {
     esac
 }
 
-uninstall_termux() {
-    if dpkg -s carch > /dev/null 2>&1; then
-        dpkg -r carch
-        printf "${GREEN}==> ${NC}carch has been removed\n"
-    else
-        printf "${YELLOW}==> ${NC}carch is not installed\n"
-    fi
-}
-
-uninstall_arch() {
-    sudo pacman -R carch-bin carch-bin-debug --noconfirm
-}
-
-uninstall_rpm() {
-    distro="$1"
-    case "$distro" in
-        fedora)   sudo dnf remove carch -y ;;
-        opensuse) sudo zypper remove -y carch ;;
-    esac
-}
-
 main() {
-    action="${1:-install}"
-
-    case "$action" in
-        install | uninstall | update) ;;
-        *)
-            printf "${RED}Error:${NC} Invalid action '%s'\n" "$action"
-            show_usage
-            ;;
-    esac
-
     distro=$(detect_distro)
 
     if [ "$distro" = "unsupported" ]; then
@@ -158,29 +119,10 @@ main() {
         exit 1
     fi
 
-    case "$action" in
-        install)
-            case "$distro" in
-                termux)            install_termux ;;
-                arch)              install_arch ;;
-                fedora | opensuse) install_rpm "$distro" ;;
-            esac
-            ;;
-        uninstall)
-            case "$distro" in
-                termux)            uninstall_termux ;;
-                arch)              uninstall_arch ;;
-                fedora | opensuse) uninstall_rpm "$distro" ;;
-            esac
-            ;;
-        update)
-            printf "${GREEN}==> ${NC}Updating carch...\n"
-            case "$distro" in
-                termux)            install_termux ;;
-                arch)              install_arch ;;
-                fedora | opensuse) install_rpm "$distro" ;;
-            esac
-            ;;
+    case "$distro" in
+        termux)            install_termux ;;
+        arch)              install_arch ;;
+        fedora | opensuse) install_rpm "$distro" ;;
     esac
 }
 


### PR DESCRIPTION
### Description

since we have update/uninstall command for carch in install script, i don't think this is a straight way to just update/uninstall through calling the install script. instead we can just bake this command into our cli commands.rs that directly does it within the compiled binary rather than running the binary and running another curl script.

i guess this will be the better approach for specially the commands area.
so we are rewriting the update/uninstall in rust via command.rs

things changed: 
- most of the thing is just the same, detecting across the distro, update does the same thing as install script does. uninstall just detects distro and uninstalls. also i didn't remove the cargo area. like most users if they use carch, i don't think they use cargo install. well in case for some users that is still there. a simple prompt/question will be at the start of running this command that asks from which medium you installed carch (cargo/install script, basically package manager like that) and it works as you answer. if you are using install script then use `p` for package manager or `c` if it is installed from direct cargo.
- `PermissionsExt` is no longer needed for permission tasks as now we are not calling any outside shell script for any task.

### Changes
- [x] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [ ] Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] UI/UX <!-- Enhancement -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->
- [ ] Documentation <!-- changes related to the readme.md or any other markdown files -->
