### PR TITLE
feat(rust): cleanup code and rename functions

### DIFF
--- a/carch-cli/src/commands.rs
+++ b/carch-cli/src/commands.rs
@@ -18,7 +18,7 @@ pub fn check_for_updates() -> Result<()> {
             println!("Latest version: {latest_version}");
 
             if latest_version != current_version {
-                println!("\nA new version of Carch is available!");
+                println!("\nUpdate available!");
                 println!("Run 'carch update' to update to the latest version.");
             } else {
                 println!("\nYou are using the latest version of Carch.");
@@ -236,17 +236,17 @@ fn uninstall_for_distro(distro: &Distro) -> Result<()> {
 
 enum InstallMethod {
     Cargo,
-    PackageManager,
+    InstallScript,
 }
 
 fn get_install_method() -> Result<InstallMethod> {
-    print!("Installed via (c)argo or (p)ackage manager? ");
+    print!("Installed via (c)argo or (i)nstall script? ");
     io::stdout().flush()?;
     let mut choice = String::new();
     io::stdin().read_line(&mut choice)?;
     match choice.trim().to_lowercase().as_str() {
         "c" | "cargo" => Ok(InstallMethod::Cargo),
-        "p" | "package manager" => Ok(InstallMethod::PackageManager),
+        "i" | "install script" => Ok(InstallMethod::InstallScript),
         _ => Err(CarchError::Command("Invalid choice. Please run the command again.".into())),
     }
 }
@@ -264,7 +264,7 @@ pub fn update() -> Result<()> {
         InstallMethod::Cargo => {
             run_command(Command::new("cargo").arg("install").arg("carch-cli").arg("--force"))?;
         }
-        InstallMethod::PackageManager => {
+        InstallMethod::InstallScript => {
             let distro = detect_distro()?;
             install_for_distro(&distro)?;
         }
@@ -286,7 +286,7 @@ pub fn uninstall() -> Result<()> {
         InstallMethod::Cargo => {
             run_command(Command::new("cargo").arg("uninstall").arg("carch-cli"))?;
         }
-        InstallMethod::PackageManager => {
+        InstallMethod::InstallScript => {
             let distro = detect_distro()?;
             uninstall_for_distro(&distro)?;
         }

--- a/carch-core/src/version.rs
+++ b/carch-core/src/version.rs
@@ -8,7 +8,7 @@ struct Release {
 
 pub fn get_current_version() -> String {
     let version = env!("CARGO_PKG_VERSION");
-    format!("Carch version {version}")
+    format!("v{version}")
 }
 
 pub fn get_latest_version() -> Result<String> {

--- a/typos.toml
+++ b/typos.toml
@@ -3,6 +3,7 @@
 [default]
 [default.extend-words]
 ratatui = "ratatui"
+nstall = "nstall"
 
 [files]
 extend-exclude = ["CHANGELOG.md"]


### PR DESCRIPTION
### Description

minor cleanup; fix typos, change version text to simple `v{version}`, and rename `packagemanager` to `install script` in update/uninstall. carch is mainly installed via install script so the package manager text is a bit out of context. carch is not on official package repositories and is not installed directly by a package manager.

### Changes
- [x] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [ ] Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [ ] UI/UX <!-- Enhancement -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->
- [ ] Documentation <!-- changes related to the readme.md or any other markdown files -->