### PR TITLE
refactor(ui): clean up frontend look and feel

### DIFF
--- a/carch-core/src/ui/app.rs
+++ b/carch-core/src/ui/app.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
+use std::process::Command;
 
 use log::info;
 use ratatui::layout::Rect;
@@ -10,6 +11,60 @@ use super::state::{
 };
 use crate::ui::state::{ScriptItem, UiOptions};
 use crate::ui::theme::Theme;
+
+fn detect_distro() -> String {
+    if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
+        for line in content.lines() {
+            if let Some(value) = line.strip_prefix("ID=") {
+                let id = value.trim_matches('"');
+                let name = match id {
+                    "arch" | "manjaro" | "endeavouros" => "Arch",
+                    "fedora" => "Fedora",
+                    "opensuse-tumbleweed" | "opensuse-leap" | "opensuse" => "openSUSE",
+                    "debian" | "ubuntu" | "linuxmint" | "pop" | "zorin" => "Debian",
+                    "alpine" => "Alpine",
+                    "void" => "Void",
+                    "gentoo" => "Gentoo",
+                    "nixos" => "NixOS",
+                    "termux" => "Termux",
+                    _ => "",
+                };
+                if !name.is_empty() {
+                    return name.to_string();
+                }
+            }
+        }
+        for line in content.lines() {
+            if let Some(value) = line.strip_prefix("PRETTY_NAME=") {
+                return value.trim_matches('"').to_string();
+            }
+        }
+    }
+
+    if std::env::var("TERMUX_VERSION").is_ok() {
+        return "Termux".to_string();
+    }
+
+    let checks: &[(&str, &str)] = &[
+        ("dnf", "Fedora"),
+        ("zypper", "openSUSE"),
+        ("apt", "Debian"),
+        ("pacman", "Arch"),
+        ("apk", "Alpine"),
+        ("xbps-install", "Void"),
+        ("emerge", "Gentoo"),
+        ("nix", "NixOS"),
+        ("pkg", "Termux"),
+    ];
+
+    for (cmd, name) in checks {
+        if Command::new("command").args(["-v", cmd]).output().is_ok() {
+            return name.to_string();
+        }
+    }
+
+    "Linux".to_string()
+}
 
 impl App {
     pub fn new(options: &UiOptions) -> App {
@@ -29,6 +84,7 @@ impl App {
             modules_dir: PathBuf::new(),
             theme,
             theme_locked: options.theme_locked,
+            distro: detect_distro(),
 
             scripts: StatefulList::new(),
             categories: StatefulList::new(),

--- a/carch-core/src/ui/popups/help.rs
+++ b/carch-core/src/ui/popups/help.rs
@@ -66,10 +66,6 @@ const HELP_LINES: &[(&[&str], &[Kind])] = &[
     (&[], &[]),
     (&["Legend"], &[Kind::Header]),
     (&[], &[]),
-    (&[" [C] ", " ", "Category"], &[Kind::NavKey, Kind::Body, Kind::Body]),
-    (&[], &[]),
-    (&[" [S] ", " ", "Script"], &[Kind::NavKey, Kind::Body, Kind::Body]),
-    (&[], &[]),
     (
         &[" \u{2713} ", " ", "Script is selected (multi-select)"],
         &[Kind::NavKey, Kind::Body, Kind::Body],

--- a/carch-core/src/ui/state.rs
+++ b/carch-core/src/ui/state.rs
@@ -196,6 +196,7 @@ pub struct App {
     pub modules_dir:   PathBuf,
     pub theme:         Theme,
     pub theme_locked:  bool,
+    pub distro:        String,
 
     pub scripts:     StatefulList<ScriptItem>,
     pub categories:  StatefulList<String>,

--- a/carch-core/src/ui/widgets/category_list.rs
+++ b/carch-core/src/ui/widgets/category_list.rs
@@ -4,18 +4,18 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, List, ListItem};
 
-use crate::ui::state::App;
+use crate::ui::state::{App, FocusedPanel};
 use crate::ui::widgets::paint_rounded_highlight;
 
-const CATEGORY_TAG: &str = " [C] ";
-
 pub fn render_category_list(f: &mut Frame, app: &mut App, area: Rect) {
-    let border_color = app.theme.primary;
+    let is_focused = app.focused_panel == FocusedPanel::Categories;
+    let border_color = if is_focused { app.theme.primary } else { Color::DarkGray };
+    let border_modifier = if is_focused { Modifier::BOLD } else { Modifier::empty() };
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(border_color))
-        .style(Style::default().bg(Color::Reset));
+        .border_style(Style::default().fg(border_color).add_modifier(border_modifier));
 
     let items: Vec<ListItem> = app
         .categories
@@ -26,23 +26,18 @@ pub fn render_category_list(f: &mut Frame, app: &mut App, area: Rect) {
                 scripts.iter().filter(|item| app.is_script_selected(&item.path)).count()
             });
 
-            let tag_span = Span::styled(CATEGORY_TAG, Style::default().fg(app.theme.primary));
+            let text_color = if is_focused { app.theme.primary } else { Color::DarkGray };
 
             if selected_in_category > 0 {
-                let label = format!("{category_name} (\u{2713} {selected_in_category})");
-                let line = Line::from(vec![
-                    tag_span,
-                    Span::styled(
-                        label,
-                        Style::default().fg(app.theme.success).add_modifier(Modifier::BOLD),
-                    ),
-                ]);
+                let label = format!(" {category_name} (\u{2713} {selected_in_category})");
+                let line = Line::from(Span::styled(
+                    label,
+                    Style::default().fg(app.theme.success).add_modifier(Modifier::BOLD),
+                ));
                 ListItem::new(line)
             } else {
-                let line = Line::from(vec![
-                    tag_span,
-                    Span::styled(category_name.as_str(), Style::default().fg(app.theme.primary)),
-                ]);
+                let label = format!(" {category_name}");
+                let line = Line::from(Span::styled(label, Style::default().fg(text_color)));
                 ListItem::new(line)
             }
         })

--- a/carch-core/src/ui/widgets/header.rs
+++ b/carch-core/src/ui/widgets/header.rs
@@ -20,10 +20,12 @@ pub fn render_header(f: &mut Frame, app: &App, area: Rect) {
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(inner_area);
 
-    let total_scripts = app.all_scripts.values().map(Vec::len).sum::<usize>();
     let left_text = Text::from(Line::from(vec![
-        Span::styled("Carch", Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD)),
-        Span::raw(format!(" | Total Scripts: {total_scripts}")),
+        Span::styled(
+            " Carch  󰏗 ",
+            Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(" │ {}", app.distro)),
     ]));
     f.render_widget(Paragraph::new(left_text).alignment(Alignment::Left), chunks[0]);
 

--- a/carch-core/src/ui/widgets/script_list.rs
+++ b/carch-core/src/ui/widgets/script_list.rs
@@ -4,26 +4,29 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, List, ListItem};
 
-use crate::ui::state::App;
+use crate::ui::state::{App, FocusedPanel};
 use crate::ui::widgets::paint_rounded_highlight;
 
 fn create_block<'a>(title: &'a str, app: &App) -> Block<'a> {
-    let border_color = app.theme.secondary;
+    let is_focused = app.focused_panel == FocusedPanel::Scripts;
+    let border_color = if is_focused { app.theme.secondary } else { Color::DarkGray };
+    let border_modifier = if is_focused { Modifier::BOLD } else { Modifier::empty() };
+
     let mut block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(border_color))
-        .style(Style::default().bg(Color::Reset));
+        .border_style(Style::default().fg(border_color).add_modifier(border_modifier));
     if !title.is_empty() {
         block = block.title(title);
     }
     block
 }
 
-const SCRIPT_TAG: &str = " [S] ";
 const TICK_SUFFIX: &str = " \u{2713}";
 
 pub fn render_script_list(f: &mut Frame, app: &mut App, area: Rect) {
+    let is_focused = app.focused_panel == FocusedPanel::Scripts;
+
     let title = if app.multi_select.enabled {
         format!("[{} Selected]", app.multi_select.scripts.len())
     } else {
@@ -43,19 +46,17 @@ pub fn render_script_list(f: &mut Frame, app: &mut App, area: Rect) {
                 app.theme.success
             } else if has_desc {
                 app.theme.foreground
-            } else {
+            } else if is_focused {
                 app.theme.secondary
+            } else {
+                Color::DarkGray
             };
-            let name_modifier =
-                if is_selected { Modifier::BOLD | Modifier::UNDERLINED } else { Modifier::empty() };
+            let name_modifier = if is_selected { Modifier::BOLD } else { Modifier::empty() };
 
-            let mut spans = vec![
-                Span::styled(SCRIPT_TAG, Style::default().fg(app.theme.secondary)),
-                Span::styled(
-                    &item.name,
-                    Style::default().fg(name_color).add_modifier(name_modifier),
-                ),
-            ];
+            let mut spans = vec![Span::styled(
+                format!(" {name}", name = item.name),
+                Style::default().fg(name_color).add_modifier(name_modifier),
+            )];
             if is_selected {
                 spans.push(Span::styled(
                     TICK_SUFFIX,

--- a/carch-core/src/ui/widgets/status_bar.rs
+++ b/carch-core/src/ui/widgets/status_bar.rs
@@ -9,62 +9,39 @@ use crate::version;
 
 fn mode_info(app: &App) -> (&'static str, Color) {
     match app.mode {
-        AppMode::Normal if app.multi_select.enabled => ("[Multi-select]", app.theme.accent),
-        AppMode::Normal => ("[Normal]", app.theme.success),
-        AppMode::Preview => ("[Preview]", app.theme.primary),
-        AppMode::Search => ("[Search]", app.theme.warning),
-        AppMode::Confirm => ("[Confirm]", app.theme.error),
-        AppMode::Help => ("[Help]", app.theme.primary),
-        AppMode::Description => ("[Description]", app.theme.primary),
-        AppMode::RunScript => ("[Running]", app.theme.warning),
-        AppMode::RootWarning => ("[Root Warning]", app.theme.error),
+        AppMode::Normal if app.multi_select.enabled => ("Multi", app.theme.accent),
+        AppMode::Normal => ("Normal", app.theme.success),
+        AppMode::Preview => ("Preview", app.theme.primary),
+        AppMode::Search => ("Search", app.theme.warning),
+        AppMode::Confirm => ("Confirm", app.theme.error),
+        AppMode::Help => ("Help", app.theme.primary),
+        AppMode::Description => ("Description", app.theme.primary),
+        AppMode::RunScript => ("Running", app.theme.warning),
+        AppMode::RootWarning => ("Root Warn", app.theme.error),
     }
 }
 
 pub fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let (mode_text, mode_color) = mode_info(app);
-
-    let selected_count = if app.multi_select.enabled {
-        format!(" {} selected ", app.multi_select.scripts.len())
-    } else {
-        String::new()
-    };
-    let has_selected = !selected_count.is_empty();
     let version = version::get_current_version();
+    let sep = Span::styled(" │ ", Style::default().fg(Color::DarkGray));
 
     let mut spans = vec![
-        Span::styled(
-            format!(" Mode: {mode_text} "),
-            Style::default().fg(mode_color).add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(" "),
+        Span::styled(mode_text, Style::default().fg(mode_color).add_modifier(Modifier::BOLD)),
+        sep.clone(),
     ];
-    if has_selected {
-        spans.push(Span::styled(
-            selected_count,
-            Style::default().fg(app.theme.warning).add_modifier(Modifier::BOLD),
-        ));
-        spans.push(Span::raw(" "));
-    }
-    spans.extend([
-        Span::styled(
-            format!(" Theme: {} ", app.theme.name),
-            Style::default().fg(app.theme.secondary),
-        ),
-        Span::raw(" "),
-        Span::styled(
-            " ?: Help | q: Quit | h/l: Switch panels",
-            Style::default().fg(app.theme.accent),
-        ),
-        Span::raw(" "),
-        Span::styled(
-            format!(" {version} "),
-            Style::default().fg(app.theme.primary).add_modifier(Modifier::BOLD),
-        ),
-    ]);
+
+    spans.push(Span::styled(app.theme.name.as_str(), Style::default().fg(app.theme.secondary)));
+    spans.push(sep.clone());
+    spans.push(Span::styled("?:Help  q:Quit", Style::default().fg(app.theme.accent)));
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(
+        version,
+        Style::default().fg(app.theme.primary).add_modifier(Modifier::BOLD),
+    ));
 
     let status = Line::from(spans);
-    let status_widget = Paragraph::new(status).style(Style::default().bg(Color::Reset));
+    let status_widget = Paragraph::new(status);
 
     f.render_widget(status_widget, area);
 }


### PR DESCRIPTION
### Description

things changed:-

- remove [c] [s] tags from categories and script side tui
- add focus indicator for doing back and fourth in category and script side tui. ( like dim the other side )
- clean up status widget making more minimal
- add nerd icon in carch header
- add distro detection to show using linux distro at top header

### Changes
- [x] Updates <!-- Added/updated scripts or configurations or others -->
- [ ] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [ ] Fixes <!-- Fixes Scripts/Other -->
- [ ] Feature <!-- Added -->
- [x] UI/UX <!-- Enhancement -->
- [ ] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->
- [ ] Documentation <!-- changes related to the readme.md or any other markdown files -->

<!-- Add any screenshots to help explain your changes or to demonstrate the new feature. -->

https://github.com/user-attachments/assets/42e1bac5-29d8-4bc6-b2b3-585aeb3fcce2


