### PR TITLE
feat: add setup command, cargo-binstall and simplify release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,7 @@ jobs:
       - name: Set up version variables
         run: |
           VERSION=$(echo "${{ github.event.inputs.tag_version }}" | sed 's/^v//')
-          CURRENT_MONTH=$(date +'%B')
-          CURRENT_YEAR=$(date +'%Y')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "CURRENT_MONTH=$CURRENT_MONTH" >> $GITHUB_ENV
-          echo "CURRENT_YEAR=$CURRENT_YEAR" >> $GITHUB_ENV
-
-      - name: Debug input values
-        run: |
-          echo "Update version input: '${{ github.event.inputs.update_version }}'"
-          echo "Update version type: $(echo '${{ github.event.inputs.update_version }}' | wc -c)"
 
       - name: Update Cargo.toml version
         if: ${{ github.event.inputs.update_version == 'true' }}
@@ -112,59 +103,12 @@ jobs:
             --target-dir=build \
             --target=aarch64-unknown-linux-musl
 
-      - name: Generate completions
+      - name: Copy raw binaries and checksums
         run: |
-          mkdir -p completions
-          ./build/x86_64-unknown-linux-musl/release/carch completions bash > completions/carch.bash
-          ./build/x86_64-unknown-linux-musl/release/carch completions zsh > completions/carch.zsh
-          ./build/x86_64-unknown-linux-musl/release/carch completions fish > completions/carch.fish
-
-      - name: Generate manpage
-        run: cargo xtask man
-
-      - name: Upload completions as artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: completions
-          path: completions/
-          retention-days: 1
-
-      - name: Package x86_64 release archive
-        run: |
-          DIR="carch-x86_64-unknown-linux-musl"
-          mkdir -p "$DIR/completions" "$DIR/man"
-          cp build/x86_64-unknown-linux-musl/release/carch "$DIR/"
-          cp completions/* "$DIR/completions/"
-          cp man/carch.1 "$DIR/man/"
-          cp carch.desktop "$DIR/"
-          tar -czf "${DIR}.tar.gz" "$DIR"
-          sha256sum "${DIR}.tar.gz" > "${DIR}.tar.gz.sha256"
-          echo "ARCHIVE_X86_64=${DIR}.tar.gz" >> $GITHUB_ENV
-          echo "ARCHIVE_X86_64_SHA=${DIR}.tar.gz.sha256" >> $GITHUB_ENV
-
-      - name: Package aarch64 release archive
-        run: |
-          DIR="carch-aarch64-unknown-linux-musl"
-          mkdir -p "$DIR/completions" "$DIR/man"
-          cp build/aarch64-unknown-linux-musl/release/carch "$DIR/"
-          cp completions/* "$DIR/completions/"
-          cp man/carch.1 "$DIR/man/"
-          cp carch.desktop "$DIR/"
-          tar -czf "${DIR}.tar.gz" "$DIR"
-          sha256sum "${DIR}.tar.gz" > "${DIR}.tar.gz.sha256"
-          echo "ARCHIVE_AARCH64=${DIR}.tar.gz" >> $GITHUB_ENV
-          echo "ARCHIVE_AARCH64_SHA=${DIR}.tar.gz.sha256" >> $GITHUB_ENV
-
-      - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: linux-archives
-          path: |
-            carch-*.tar.gz
-            carch-*.tar.gz.sha256
-            build/x86_64-unknown-linux-musl/release/carch
-            build/aarch64-unknown-linux-musl/release/carch
-          retention-days: 1
+          cp build/x86_64-unknown-linux-musl/release/carch ./carch-x86_64-unknown-linux-musl
+          cp build/aarch64-unknown-linux-musl/release/carch ./carch-aarch64-unknown-linux-musl
+          sha256sum ./carch-x86_64-unknown-linux-musl > ./carch-x86_64-unknown-linux-musl.sha256
+          sha256sum ./carch-aarch64-unknown-linux-musl > ./carch-aarch64-unknown-linux-musl.sha256
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@v4
@@ -187,28 +131,17 @@ jobs:
           tag_name: ${{ github.event.inputs.tag_version }}
           name: ${{ github.event.inputs.tag_title }}
           draft: false
-          prerelease: true
+          prerelease: ${{ github.event.inputs.update_version != 'true' }}
           generate_release_notes: false
           body_path: BODY.md
-
-      - name: Copy raw binaries
-        run: |
-          cp build/x86_64-unknown-linux-musl/release/carch ./carch
-          cp build/aarch64-unknown-linux-musl/release/carch ./carch-aarch64
-          sha256sum ./carch > ./carch.sha256
-          sha256sum ./carch-aarch64 > ./carch-aarch64.sha256
 
       - name: Upload Linux assets
         run: |
           gh release upload ${{ github.event.inputs.tag_version }} \
-            ${{ env.ARCHIVE_X86_64 }} \
-            ${{ env.ARCHIVE_X86_64_SHA }} \
-            ${{ env.ARCHIVE_AARCH64 }} \
-            ${{ env.ARCHIVE_AARCH64_SHA }} \
-            ./carch \
-            ./carch.sha256 \
-            ./carch-aarch64 \
-            ./carch-aarch64.sha256
+            ./carch-x86_64-unknown-linux-musl \
+            ./carch-x86_64-unknown-linux-musl.sha256 \
+            ./carch-aarch64-unknown-linux-musl \
+            ./carch-aarch64-unknown-linux-musl.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -249,15 +182,6 @@ jobs:
       - name: Install cross
         run: cargo install cross
 
-      - name: Generate manpage
-        run: cargo xtask man
-
-      - name: Download completions
-        uses: actions/download-artifact@v7
-        with:
-          name: completions
-          path: completions/
-
       - name: Build aarch64 Android binary
         run: |
           cross build \
@@ -272,56 +196,19 @@ jobs:
             --target-dir=build \
             --target=armv7-linux-androideabi
 
-      - name: Package aarch64 Android archive
+      - name: Copy raw Android binaries and checksums
         run: |
-          DIR="carch-aarch64-linux-android"
-          mkdir -p "$DIR/completions" "$DIR/man"
-          cp build/aarch64-linux-android/release/carch "$DIR/"
-          cp completions/* "$DIR/completions/"
-          cp man/carch.1 "$DIR/man/"
-          tar -czf "${DIR}.tar.gz" "$DIR"
-          sha256sum "${DIR}.tar.gz" > "${DIR}.tar.gz.sha256"
-          echo "ARCHIVE_AARCH64_ANDROID=${DIR}.tar.gz" >> $GITHUB_ENV
-          echo "ARCHIVE_AARCH64_ANDROID_SHA=${DIR}.tar.gz.sha256" >> $GITHUB_ENV
-
-      - name: Package armv7 Android archive
-        run: |
-          DIR="carch-armv7-linux-androideabi"
-          mkdir -p "$DIR/completions" "$DIR/man"
-          cp build/armv7-linux-androideabi/release/carch "$DIR/"
-          cp completions/* "$DIR/completions/"
-          cp man/carch.1 "$DIR/man/"
-          tar -czf "${DIR}.tar.gz" "$DIR"
-          sha256sum "${DIR}.tar.gz" > "${DIR}.tar.gz.sha256"
-          echo "ARCHIVE_ARMV7_ANDROID=${DIR}.tar.gz" >> $GITHUB_ENV
-          echo "ARCHIVE_ARMV7_ANDROID_SHA=${DIR}.tar.gz.sha256" >> $GITHUB_ENV
-
-      - name: Upload Android archives as artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-archives
-          path: |
-            carch-*.tar.gz
-            carch-*.tar.gz.sha256
-          retention-days: 1
-
-      - name: Copy raw Android binaries
-        run: |
-          cp build/aarch64-linux-android/release/carch ./carch-aarch64-android
-          cp build/armv7-linux-androideabi/release/carch ./carch-armv7-android
-          sha256sum ./carch-aarch64-android > ./carch-aarch64-android.sha256
-          sha256sum ./carch-armv7-android > ./carch-armv7-android.sha256
+          cp build/aarch64-linux-android/release/carch ./carch-aarch64-linux-android
+          cp build/armv7-linux-androideabi/release/carch ./carch-armv7-linux-androideabi
+          sha256sum ./carch-aarch64-linux-android > ./carch-aarch64-linux-android.sha256
+          sha256sum ./carch-armv7-linux-androideabi > ./carch-armv7-linux-androideabi.sha256
 
       - name: Upload Android assets
         run: |
           gh release upload ${{ github.event.inputs.tag_version }} \
-            ${{ env.ARCHIVE_AARCH64_ANDROID }} \
-            ${{ env.ARCHIVE_AARCH64_ANDROID_SHA }} \
-            ${{ env.ARCHIVE_ARMV7_ANDROID }} \
-            ${{ env.ARCHIVE_ARMV7_ANDROID_SHA }} \
-            ./carch-aarch64-android \
-            ./carch-aarch64-android.sha256 \
-            ./carch-armv7-android \
-            ./carch-armv7-android.sha256
+            ./carch-aarch64-linux-android \
+            ./carch-aarch64-linux-android.sha256 \
+            ./carch-armv7-linux-androideabi \
+            ./carch-armv7-linux-androideabi.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,8 @@ dependencies = [
  "carch-core",
  "clap",
  "clap_complete",
+ "clap_mangen",
+ "dirs",
  "env_logger",
  "log",
  "reqwest",
@@ -432,6 +434,27 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1082,6 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1288,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "palette"
@@ -1633,6 +1671,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.12.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/carch-cli/Cargo.toml
+++ b/carch-cli/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 license.workspace = true
 edition.workspace = true
 readme.workspace = true
-include = ["src", "Cargo.toml", "../man/carch.1", "../carch.desktop"]
+include = ["src", "Cargo.toml", "../carch.desktop"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"

--- a/carch-cli/Cargo.toml
+++ b/carch-cli/Cargo.toml
@@ -10,7 +10,13 @@ categories.workspace = true
 license.workspace = true
 edition.workspace = true
 readme.workspace = true
-include = ["src", "Cargo.toml", "../man/carch.1"]
+include = ["src", "Cargo.toml", "../man/carch.1", "../carch.desktop"]
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "bin"
+disabled-strategies = ["quick-install", "compile"]
 
 [lib]
 name = "carch_cli"
@@ -19,7 +25,9 @@ path = "src/lib.rs"
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 clap_complete = "4.6.5"
+clap_mangen = "0.3"
 carch-core = { path = "../carch-core", version = "5.4.4" }
+dirs = "6"
 log = { workspace = true }
 env_logger = { workspace = true }
 tempfile = { workspace = true }

--- a/carch-cli/src/args.rs
+++ b/carch-cli/src/args.rs
@@ -83,6 +83,11 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    #[command(about = "Install shell completions, man page, and desktop file")]
+    Setup {
+        #[arg(long, help = "Preview what would be installed without writing files")]
+        dry_run: bool,
+    },
     #[command(about = "Check for updates")]
     CheckUpdate,
     #[command(about = "Update the application")]
@@ -136,6 +141,7 @@ pub fn parse_args() -> Result<()> {
     }
 
     match cli.command {
+        Some(Commands::Setup { dry_run }) => crate::setup::run_setup(dry_run),
         Some(Commands::CheckUpdate) => {
             info!("Checking for updates");
             commands::check_for_updates()

--- a/carch-cli/src/lib.rs
+++ b/carch-cli/src/lib.rs
@@ -7,6 +7,7 @@ use tempfile::TempDir;
 
 pub mod args;
 pub mod commands;
+pub mod setup;
 pub mod state;
 
 use crate::args::Settings;

--- a/carch-cli/src/setup.rs
+++ b/carch-cli/src/setup.rs
@@ -1,0 +1,170 @@
+use crate::args::Cli;
+use carch_core::error::{CarchError, Result};
+use clap::CommandFactory;
+use std::fs;
+use std::path::PathBuf;
+
+const DESKTOP_FILE: &str = include_str!("../../carch.desktop");
+
+fn is_termux() -> bool {
+    std::env::var("TERMUX_VERSION").is_ok() || std::env::var("PREFIX").is_ok()
+}
+
+fn is_root() -> bool {
+    std::env::var("EUID").is_ok_and(|v| v == "0")
+}
+
+fn termux_prefix() -> PathBuf {
+    std::env::var("PREFIX")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/data/data/com.termux/files/usr"))
+}
+
+fn bash_completion_dir() -> PathBuf {
+    if is_termux() {
+        termux_prefix().join("share/bash-completion/completions")
+    } else if is_root() {
+        PathBuf::from("/usr/share/bash-completion/completions")
+    } else {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+            .join("bash-completion/completions")
+    }
+}
+
+fn zsh_completion_dir() -> PathBuf {
+    if is_termux() {
+        termux_prefix().join("share/zsh/site-functions")
+    } else if is_root() {
+        PathBuf::from("/usr/share/zsh/site-functions")
+    } else {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+            .join("zsh/site-functions")
+    }
+}
+
+fn fish_completion_dir() -> PathBuf {
+    if is_termux() {
+        termux_prefix().join("share/fish/vendor_completions.d")
+    } else if is_root() {
+        PathBuf::from("/usr/share/fish/vendor_completions.d")
+    } else {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+            .join("fish/vendor_completions.d")
+    }
+}
+
+fn man_dir() -> PathBuf {
+    if is_termux() {
+        termux_prefix().join("share/man/man1")
+    } else if is_root() {
+        PathBuf::from("/usr/share/man/man1")
+    } else {
+        dirs::data_dir().unwrap_or_else(|| PathBuf::from("~/.local/share")).join("man/man1")
+    }
+}
+
+fn write_file(path: &PathBuf, content: &[u8], dry_run: bool) -> Result<()> {
+    if dry_run {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)?;
+    Ok(())
+}
+
+pub fn run_setup(dry_run: bool) -> Result<()> {
+    let mut cmd = Cli::command();
+    cmd = cmd.name("carch");
+
+    if dry_run {
+        println!("(dry run) Would install:");
+    }
+
+    let mut installed = Vec::new();
+
+    let bash_path = bash_completion_dir().join("carch");
+    let mut bash_content = Vec::new();
+    clap_complete::generate(
+        clap_complete::Shell::Bash,
+        &mut cmd.clone(),
+        "carch",
+        &mut bash_content,
+    );
+    write_file(&bash_path, &bash_content, dry_run)?;
+    installed.push(format!("bash completions → {}", bash_path.display()));
+
+    let zsh_path = zsh_completion_dir().join("_carch");
+    let mut zsh_content = Vec::new();
+    clap_complete::generate(clap_complete::Shell::Zsh, &mut cmd.clone(), "carch", &mut zsh_content);
+    write_file(&zsh_path, &zsh_content, dry_run)?;
+    installed.push(format!("zsh completions → {}", zsh_path.display()));
+
+    let fish_path = fish_completion_dir().join("carch.fish");
+    let mut fish_content = Vec::new();
+    clap_complete::generate(
+        clap_complete::Shell::Fish,
+        &mut cmd.clone(),
+        "carch",
+        &mut fish_content,
+    );
+    write_file(&fish_path, &fish_content, dry_run)?;
+    installed.push(format!("fish completions → {}", fish_path.display()));
+
+    let date = std::process::Command::new("date")
+        .arg("+%B %d, %Y")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let man = clap_mangen::Man::new(cmd.clone())
+        .title("carch")
+        .section("1")
+        .date(date.trim())
+        .source("Carch")
+        .manual("Carch");
+
+    let mut buf = Vec::new();
+    man.render(&mut buf)?;
+
+    let mut content = String::from_utf8(buf)
+        .map_err(|e| CarchError::Command(format!("man page UTF-8 error: {e}")))?;
+    for sub in cmd.get_subcommands() {
+        let name = sub.get_name();
+        let escaped = name.replace('-', "\\-");
+        let old = format!("carch\\-{escaped}(1)");
+        let new = format!("\\fB{name}\\fR");
+        content = content.replace(&old, &new);
+    }
+    content = content.replace("carch\\-help(1)", "\\fBhelp\\fR");
+
+    let man_path = man_dir().join("carch.1");
+    write_file(&man_path, content.as_bytes(), dry_run)?;
+    installed.push(format!("man page → {}", man_path.display()));
+
+    if !is_termux() {
+        let desktop_dir = if is_root() {
+            PathBuf::from("/usr/share/applications")
+        } else {
+            dirs::data_dir().unwrap_or_else(|| PathBuf::from("~/.local/share")).join("applications")
+        };
+        let desktop_path = desktop_dir.join("carch.desktop");
+        write_file(&desktop_path, DESKTOP_FILE.as_bytes(), dry_run)?;
+        installed.push(format!("desktop file → {}", desktop_path.display()));
+    }
+
+    for msg in &installed {
+        if dry_run {
+            println!("  {msg}");
+        } else {
+            println!("✓ {msg}");
+        }
+    }
+
+    Ok(())
+}

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ allow = [
   "BSD-3-Clause",
   "CDLA-Permissive-2.0",
   "ISC",
+  "MPL-2.0",
 ]
 
 [licenses.private]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,60 +72,21 @@ echo "$BINARY $VERSION ($TARGET)"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-ARCHIVE="${BINARY}-${TARGET}.tar.gz"
-
-curl -fsSL "https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE" -o "$TMPDIR/$ARCHIVE"
-curl -fsSL "https://github.com/$REPO/releases/download/$VERSION/$ARCHIVE.sha256" -o "$TMPDIR/$ARCHIVE.sha256"
+ASSET="$BINARY-$TARGET"
+curl -fsSL "https://github.com/$REPO/releases/download/$VERSION/$ASSET" -o "$TMPDIR/$BINARY"
+curl -fsSL "https://github.com/$REPO/releases/download/$VERSION/$ASSET.sha256" -o "$TMPDIR/$BINARY.sha256"
 
 cd "$TMPDIR"
-sha256sum -c "$ARCHIVE.sha256"
-tar xzf "$ARCHIVE"
-cd "${BINARY}-${TARGET}"
+sha256sum -c "$BINARY.sha256"
+chmod 755 "$BINARY"
 
 if [ "$IS_ANDROID" = "true" ]; then
     install -Dm755 "$BINARY" "$PREFIX/bin/$BINARY"
-
-    if [ -d "completions" ]; then
-        mkdir -p "$PREFIX/share/bash-completion/completions" \
-            "$PREFIX/share/zsh/site-functions" \
-            "$PREFIX/share/fish/vendor_completions.d"
-
-        [ -f "completions/$BINARY.bash" ] && cp "completions/$BINARY.bash" \
-            "$PREFIX/share/bash-completion/completions/$BINARY"
-        [ -f "completions/$BINARY.zsh" ] && cp "completions/$BINARY.zsh" \
-            "$PREFIX/share/zsh/site-functions/_$BINARY"
-        [ -f "completions/$BINARY.fish" ] && cp "completions/$BINARY.fish" \
-            "$PREFIX/share/fish/vendor_completions.d/$BINARY.fish"
-    fi
-
-    if [ -f "man/$BINARY.1" ]; then
-        install -Dm644 "man/$BINARY.1" "$PREFIX/share/man/man1/$BINARY.1"
-    fi
 else
-    sudo install -Dm755 "$BINARY" "/usr/local/bin/$BINARY"
-
-    if [ -d "completions" ]; then
-        sudo mkdir -p /usr/share/bash-completion/completions \
-            /usr/share/zsh/site-functions \
-            /usr/share/fish/vendor_completions.d
-
-        [ -f "completions/$BINARY.bash" ] && sudo cp "completions/$BINARY.bash" \
-            /usr/share/bash-completion/completions/$BINARY
-        [ -f "completions/$BINARY.zsh" ] && sudo cp "completions/$BINARY.zsh" \
-            /usr/share/zsh/site-functions/_$BINARY
-        [ -f "completions/$BINARY.fish" ] && sudo cp "completions/$BINARY.fish" \
-            /usr/share/fish/vendor_completions.d/$BINARY.fish
-    fi
-
-    if [ -f "man/$BINARY.1" ]; then
-        sudo install -Dm644 "man/$BINARY.1" /usr/share/man/man1/$BINARY.1
-    fi
-
-    if [ -f "$BINARY.desktop" ]; then
-        sudo install -Dm644 "$BINARY.desktop" /usr/share/applications/$BINARY.desktop
-    fi
-
+    sudo mkdir -p /usr/local/bin
+    sudo install -m755 "$BINARY" "/usr/local/bin/$BINARY"
     mandb -q 2> /dev/null || true
 fi
 
 echo "$BINARY installed successfully"
+echo "Run 'carch setup' to install shell completions, man page, and desktop file."


### PR DESCRIPTION
### Description

changes:

- add npltz setup with --dry-run to install completions, man pages, and desktop file
- switch releases from tarballs to raw binaries
- add cargo-binstall metadata to Cargo.toml
- simplify install.sh for raw binary downloads
- updates docs


### Changes
- [ ] Updates <!-- Added/updated scripts or configurations or others -->
- [x] Remove <!-- Bad Script/Code or others-->
- [ ] Fixed issue #[issue number].
- [x] Improved <!-- optimized existing functionality -->
- [ ] Fixes <!-- Fixes Scripts/Other -->
- [x] Feature <!-- Added -->
- [ ] UI/UX <!-- Enhancement -->
- [x] CI/CD <!-- Changes related to GitHub Actions, workflows, or automation -->
- [ ] Documentation <!-- changes related to the readme.md or any other markdown files -->
